### PR TITLE
Add internal permissions using 'moderator' roles and implement those in settings

### DIFF
--- a/src/cogs/manage_moderators.py
+++ b/src/cogs/manage_moderators.py
@@ -1,3 +1,6 @@
+import logging
+from typing import List, Union
+
 from discord.ext import commands
 import discord
 
@@ -9,6 +12,33 @@ from cogs.settings import is_arg, is_arg_int
 
 
 toggle_mod_usage = f"Usage: `{PREFIX}mrole [role id | @role]`"
+logger = logging.getLogger('my-bot')
+
+
+def get_mod_roles(guild: discord.Guild) -> List[discord.Member]:
+    """
+    Gets all roles that have moderator permissions inside the bot.\n
+    Removes roles that the bot can't find from database
+
+    :param guild: guild to search on
+
+    :return: List of all (moderator) roles (discord object) that the bot can find on the guild
+    """
+    # load roles
+    entries = dba.get_settings_for(guild.id, setting="mod-role")
+    if not entries:
+        return []
+    roles = []
+    for entry in entries:
+        role = guild.get_role(int(entry.value))
+        # if role can't be extracted it's probably deleted and should be removed
+        if not role:
+            logger.info(f"{guild.name}: Can't find role with ID {entry.id} - removing.")
+            dba.del_setting(guild.id, entry.value, entry.setting)
+            continue
+
+        roles.append(role)
+    return roles
 
 
 class Access(commands.Cog):

--- a/src/cogs/manage_moderators.py
+++ b/src/cogs/manage_moderators.py
@@ -109,8 +109,27 @@ class Access(commands.Cog):
             )
         )
 
+    @commands.command(name='mroles', alias=['modroles', "modroles", "mod-roles"],
+                      help='Display all roles that can configure the default wordpools')
+    async def list_moderators(self, ctx):
 
-def setup(bot: commands.Bot):
-    bot.add_cog(Access(bot))
+        roles = get_mod_roles(ctx.guild)
+        if not roles:
+            await ctx.send(
+                embed=ut.make_embed(
+                    name='No moderator-roles configured',
+                    value=f'{help_toggle_mod_usage} grants a role moderator permissions',
+                    color=ut.yellow
+                )
+            )
+            return
+
+        text = '\n'.join([f'{r.mention} ID: {r.id}' for r in roles])
+        await ctx.send(
+            embed=ut.make_embed(
+                name='Roles that can edit the used wordpools:',
+                value=text
+            )
+        )
 
 

--- a/src/cogs/manage_moderators.py
+++ b/src/cogs/manage_moderators.py
@@ -133,3 +133,5 @@ class Access(commands.Cog):
         )
 
 
+def setup(bot: commands.Bot):
+    bot.add_cog(Access(bot))

--- a/src/cogs/manage_moderators.py
+++ b/src/cogs/manage_moderators.py
@@ -1,0 +1,84 @@
+from discord.ext import commands
+import discord
+
+import utils as ut
+import database.db as db
+import database.db_access as dba
+from environment import PREFIX
+from cogs.settings import is_arg, is_arg_int
+
+
+toggle_mod_usage = f"Usage: `{PREFIX}mrole [role id | @role]`"
+
+
+class Access(commands.Cog):
+    """Manage who can configure the bot on your server"""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.has_permissions(administrator=True)
+    @commands.command(name="mod-role", aliases=["mrole","config-role", "selrole", "toggle_role", "crole"],
+                      help="Allow roles to select the default wordpools.\n\n"
+                           "This command _toggles_ the permissions for a role. \n"
+                           f"Use the same command to remove it\n\n"
+                           f"{toggle_mod_usage}\n\n"
+                           
+                           f"_administrator permissions required_")
+    async def toggle_mod(self, ctx: commands.Context, *role):
+        if not is_arg(role, 1):
+            await ctx.send(
+                embed=ut.make_embed(
+                    name=f"This command needs one additional argument:\n\n",
+                    value=f"{toggle_mod_usage}\n\n",
+                    color=ut.yellow
+                ))
+            return
+
+        # get role by extracting id and tying to get role on guild
+        id_input = ut.extract_id_from_message(role[0])
+
+        role: discord.Role = ctx.guild.get_role(id_input)
+        if not role:
+            await ctx.send(
+                embed=ut.make_embed(
+                    name="No ID given",
+                    value=f"This command needs a role ID or a role mention as argument to work.\n\n"
+                          f"{toggle_mod_usage}\n\n",
+                    color=ut.yellow
+                )
+            )
+
+        # try to get entry like this from database
+        session = db.open_session()
+        entry = dba.get_setting(ctx.guild.id, str(id_input), setting='mod-role', session=session)
+        # wiping entry if exists to delete privileges
+        if entry:
+            session.delete(entry)
+            session.commit()
+            await ctx.send(
+                embed=ut.make_embed(
+                    name='Removed privileges',
+                    value=f"Successfully removed mod privileges for {role.mention}",
+                    color=ut.orange
+                )
+            )
+            return
+
+        # we need to add a user if we reach this point - let's go
+        dba.add_setting(ctx.guild.id, str(id_input), setting='mod-role', set_by=ctx.author.id)
+        await ctx.send(
+            embed=ut.make_embed(
+                name='Added privileges',
+                value=f"Successfully added mod privileges for {role.mention}\n"
+                      f"Everyone with this role is now able to configure the preset wordpools the bot chooses from.\n",
+                footer="Use the same command again to remove those privileges again.",
+                color=ut.green
+            )
+        )
+
+
+def setup(bot: commands.Bot):
+    bot.add_cog(Access(bot))
+
+

--- a/src/cogs/manage_moderators.py
+++ b/src/cogs/manage_moderators.py
@@ -12,34 +12,6 @@ from cogs.settings import is_arg, is_arg_int
 
 help_toggle_mod_usage = f"`{PREFIX}mrole [role id | @role]`"
 
-logger = logging.getLogger('my-bot')
-
-
-def get_mod_roles(guild: discord.Guild) -> List[discord.Member]:
-    """
-    Gets all roles that have moderator permissions inside the bot.\n
-    Removes roles that the bot can't find from database
-
-    :param guild: guild to search on
-
-    :return: List of all (moderator) roles (discord object) that the bot can find on the guild
-    """
-    # load roles
-    entries = dba.get_settings_for(guild.id, setting="mod-role")
-    if not entries:
-        return []
-    roles = []
-    for entry in entries:
-        role = guild.get_role(int(entry.value))
-        # if role can't be extracted it's probably deleted and should be removed
-        if not role:
-            logger.info(f"{guild.name}: Can't find role with ID {entry.id} - removing.")
-            dba.del_setting(guild.id, entry.value, entry.setting)
-            continue
-
-        roles.append(role)
-    return roles
-
 
 class Access(commands.Cog):
     """

--- a/src/cogs/manage_moderators.py
+++ b/src/cogs/manage_moderators.py
@@ -10,8 +10,8 @@ import database.db_access as dba
 from environment import PREFIX
 from cogs.settings import is_arg, is_arg_int
 
+help_toggle_mod_usage = f"`{PREFIX}mrole [role id | @role]`"
 
-toggle_mod_usage = f"Usage: `{PREFIX}mrole [role id | @role]`"
 logger = logging.getLogger('my-bot')
 
 
@@ -50,19 +50,19 @@ class Access(commands.Cog):
         self.bot = bot
 
     @commands.has_permissions(administrator=True)
-    @commands.command(name="mod-role", aliases=["mrole","config-role", "selrole", "toggle_role", "crole"],
+    @commands.command(name="mod-role", aliases=["mrole", "config-role", "selrole", "toggle_role", "crole"],
                       help="Allow roles to select the default wordpools.\n\n"
                            "This command _toggles_ the permissions for a role. \n"
                            f"Use the same command to remove it\n\n"
-                           f"{toggle_mod_usage}\n\n"
-                           
+                           f"Use: {help_toggle_mod_usage}\n\n"
+
                            f"_administrator permissions required_")
     async def toggle_mod(self, ctx: commands.Context, *role):
         if not is_arg(role, 1):
             await ctx.send(
                 embed=ut.make_embed(
                     name=f"This command needs one additional argument:\n\n",
-                    value=f"{toggle_mod_usage}\n\n",
+                    value=f"Use: {help_toggle_mod_usage}\n\n",
                     color=ut.yellow
                 ))
             return
@@ -76,7 +76,7 @@ class Access(commands.Cog):
                 embed=ut.make_embed(
                     name="No ID given",
                     value=f"This command needs a role ID or a role mention as argument to work.\n\n"
-                          f"{toggle_mod_usage}\n\n",
+                          f"Use: {help_toggle_mod_usage}\n\n",
                     color=ut.yellow
                 )
             )

--- a/src/cogs/manage_moderators.py
+++ b/src/cogs/manage_moderators.py
@@ -12,7 +12,9 @@ toggle_mod_usage = f"Usage: `{PREFIX}mrole [role id | @role]`"
 
 
 class Access(commands.Cog):
-    """Manage who can configure the bot on your server"""
+    """
+    Manage who can configure the bot on your server
+    """
 
     def __init__(self, bot):
         self.bot = bot

--- a/src/cogs/settings.py
+++ b/src/cogs/settings.py
@@ -119,7 +119,9 @@ async def validate_list_name(ctx: commands.Context, selection: Tuple, command_na
 
 
 class Wordpools(commands.Cog):
-    """Configure the lists used for your games"""
+    """
+    Configure the lists used for your games
+    """
 
     def __init__(self, bot):
         self.vot = bot

--- a/src/cogs/settings.py
+++ b/src/cogs/settings.py
@@ -3,7 +3,7 @@ Written by:
 https://github.com/nonchris/
 """
 
-from typing import List, Tuple, Union
+from typing import Tuple
 
 from discord.ext import commands
 import discord
@@ -12,17 +12,7 @@ import utils as ut
 import database.db as db
 import database.db_access as dba
 from environment import PREFIX
-from game_management.word_pools import available_word_pools, get_words, get_description
-
-# TODO: Load this list by reading the json and using dict.key()
-available_word_lists = ["classic_main", "classic_weird", "extension_main", "extension_weird", "nsfw", "gandhi"]
-
-
-def get_lists_names() -> List[str]:
-    """
-    Cheap getter of all lists available, maybe useful for external access to make accesses more beautiful
-    """
-    return available_word_lists
+from game_management.word_pools import available_word_pools, get_description
 
 
 def get_list_formatted(format_symbol="_", join_style="\n") -> str:
@@ -33,7 +23,7 @@ def get_list_formatted(format_symbol="_", join_style="\n") -> str:
     :param join_style: string that's used to join all words together. Want comma or line break? - You choice!
     """
     replace_str = "\_"
-    nice_list = [f'{format_symbol}{word.replace("_", replace_str)}{format_symbol}' for word in available_word_lists]
+    nice_list = [f'{format_symbol}{word.replace("_", replace_str)}{format_symbol}' for word in available_word_pools()]
     return join_style.join(nice_list)
 
 
@@ -112,7 +102,7 @@ async def validate_list_name(ctx: commands.Context, selection: Tuple, command_na
 
     # TODO: check if more than one input maybe enable two list at once?
     selected_list = selection[0]
-    if selected_list not in available_word_lists:
+    if selected_list not in available_word_pools():
         await ctx.send(embed=ut.make_embed(
             name="Wrong argument", color=ut.yellow,
             value="Hey, you need to enter a wordlist.\n"
@@ -144,7 +134,7 @@ class Settings(commands.Cog):
             value=f'Verwendet `{PREFIX}enlist [list_name] [Optional: weight]`, um einen der unteren Pools hinzuzufügen',
             color=ut.green
         )
-        for wordpool in available_word_lists:
+        for wordpool in available_word_pools():
             embed.add_field(
                 name=wordpool,
                 value=get_description(wordpool)

--- a/src/cogs/settings.py
+++ b/src/cogs/settings.py
@@ -50,11 +50,14 @@ def is_arg_int(arg: str) -> bool:
         return False
 
 
-def is_second_arg(selection: Tuple) -> bool:
+def is_arg(selection: Tuple, elements=1) -> bool:
     """
-    simply takes a tuple and checks if it has more than one entry
+    simply takes a tuple and checks if it has at least as much entries as arg requests
+    
+    :arg selection: The tuple / list to inspect
+    :param elements: how many entries the tuple should have
     """
-    if len(selection) < 2:
+    if len(selection) < elements:
         return False
     return True
 
@@ -67,7 +70,7 @@ def get_weight_arg(selection: Tuple) -> Tuple[int, str]:
 
     :return: integer that represents the weight (given weight if valid, else 1) and a reply/ answer string for the user.
     """
-    if not is_second_arg(selection):
+    if not is_arg(selection, elements=2):
         return 1, "Using standard weight of one, because no explicit weight was given."
 
     weight = selection[1]

--- a/src/cogs/settings.py
+++ b/src/cogs/settings.py
@@ -121,7 +121,7 @@ class Settings(commands.Cog):
     def __init__(self, bot):
         self.vot = bot
 
-    @commands.command(name="available", aliases=["available-list", "avl"],
+    @commands.command(name="available", aliases=["available-lists", "available-pools", "avl", "avp", "pools"],
                       help="Zeigt alle verfügbaren Wörterpools an")
     async def display_available_wordpools(self, ctx):
         """

--- a/src/cogs/settings.py
+++ b/src/cogs/settings.py
@@ -118,7 +118,7 @@ async def validate_list_name(ctx: commands.Context, selection: Tuple, command_na
     return selected_list
 
 
-class Settings(commands.Cog):
+class Wordpools(commands.Cog):
     """Configure the lists used for your games"""
 
     def __init__(self, bot):
@@ -228,4 +228,4 @@ class Settings(commands.Cog):
 
 
 def setup(bot: commands.Bot):
-    bot.add_cog(Settings(bot))
+    bot.add_cog(Wordpools(bot))

--- a/src/cogs/settings.py
+++ b/src/cogs/settings.py
@@ -13,6 +13,7 @@ import database.db as db
 import database.db_access as dba
 from environment import PREFIX
 from game_management.word_pools import available_word_pools, get_description
+from permission_management.moderator import is_moderator
 
 
 def get_list_formatted(format_symbol="_", join_style="\n") -> str:
@@ -118,6 +119,22 @@ async def validate_list_name(ctx: commands.Context, selection: Tuple, command_na
     return selected_list
 
 
+async def send_permission_error(ctx: commands.Context):
+    """
+    Sends a standard permission reply message\n
+    - used in enlist and delist command
+    """
+    await ctx.send(
+        embed=ut.make_embed(
+            name="You cant do this",
+            value="I'm sorry, you don't have the permission to do that.\n"
+                  f"You can use `{PREFIX}mroles` get a list of all roles that have permissions.\n\n"
+                  f"Discord Admins can add roles using: `{PREFIX}mrole [role id | @role]`",
+            color=ut.yellow
+        )
+    )
+
+
 class Wordpools(commands.Cog):
     """
     Configure the lists used for your games
@@ -167,6 +184,11 @@ class Wordpools(commands.Cog):
                       )
     async def enable_list(self, ctx: commands.Context, *selection):
 
+        # check if author is allowed to execute
+        if not is_moderator(ctx.author):
+            await send_permission_error(ctx)
+            return
+
         selected_list = await validate_list_name(ctx, selection, command_name="enlist")
         if not selected_list:
             return
@@ -214,6 +236,11 @@ class Wordpools(commands.Cog):
     @commands.command(name="delist", alias=["dellist"], help="Deactivate a wordlist for your server\n\n"
                                                              f"Usage: `{PREFIX}delist [list_name]`")
     async def deactivate_list(self, ctx, *selection):
+
+        # check if author is allowed to execute
+        if not is_moderator(ctx.author):
+            await send_permission_error(ctx)
+            return
 
         selected_list = await validate_list_name(ctx, selection, command_name="delist")
 

--- a/src/game_management/word_pools.py
+++ b/src/game_management/word_pools.py
@@ -2,7 +2,7 @@ import database.db_access as dba
 import random
 
 from discord.ext import commands
-from typing import List, Union
+from typing import List, Union, Tuple
 import json
 
 
@@ -26,6 +26,13 @@ def get_description(wordpool_name: str) -> Union[str, None]:
     if wordpool_name in available_word_pools():
         return get_wordpools()[wordpool_name]['description']
     return None
+
+
+def get_pools_with_description() -> List[Tuple[str, str]]:
+    """
+    :return: List of Tuples containing pool name and description
+    """
+    return [(pool, get_description(pool)) for pool in available_word_pools()]
 
 
 def get_words(wordpool_name: str) -> Union[List[str], None]:

--- a/src/game_management/word_pools.py
+++ b/src/game_management/word_pools.py
@@ -17,8 +17,8 @@ class WordPoolDistribution:  # Class used to manage the distribution of wordpool
         return self.distribution
 
 
-def available_word_pools():  # Give back a list of the existing word pools (in the json file)
-    return get_wordpools().keys()
+def available_word_pools():  # Give back a list of the existing word pools (in the json file) - sorted
+    return sorted(get_wordpools().keys())
 
 
 def get_description(wordpool_name: str) -> Union[str, None]:

--- a/src/main.py
+++ b/src/main.py
@@ -42,7 +42,8 @@ initial_extensions = [
     'cogs.misc',
     'cogs.help',
     'cogs.just_one',
-    'cogs.settings'
+    'cogs.settings',
+    'cogs.manage_moderators'
 ]
 
 if __name__ == '__main__':

--- a/src/permission_management/moderator.py
+++ b/src/permission_management/moderator.py
@@ -35,3 +35,24 @@ def get_mod_roles(guild: discord.Guild) -> List[discord.Member]:
     return roles
 
 
+def is_moderator(member: discord.Member) -> bool:
+    """
+    Takes a member and checks if any mod role matches with roles the member has
+
+    :param member: member to check
+
+    :return: True if member has a mod role, False else
+    """
+
+    # if member is an admin, he can do what ever he likes to do
+    if member.guild_permissions.administrator:
+        return True
+
+    # load mod roles
+    # extract only role-ids from role objects
+    mod_role_ids = set([r.id for r in get_mod_roles(member.guild.id)])
+    member_role_ids = set([r.id for r in member.roles])
+    # intersecting sets to see if any role id is in both sets which means that user has mod perms
+    intersect = mod_role_ids & member_role_ids
+
+    return True if intersect else False

--- a/src/permission_management/moderator.py
+++ b/src/permission_management/moderator.py
@@ -27,7 +27,7 @@ def get_mod_roles(guild: discord.Guild) -> List[discord.Member]:
         role = guild.get_role(int(entry.value))
         # if role can't be extracted it's probably deleted and should be removed
         if not role:
-            logger.info(f"{guild.name}: Can't find role with ID {entry.id} - removing.")
+            logger.info(f"{guild.name}: Can't find role with ID {entry.value} - removing.")
             dba.del_setting(guild.id, entry.value, entry.setting)
             continue
 
@@ -50,7 +50,7 @@ def is_moderator(member: discord.Member) -> bool:
 
     # load mod roles
     # extract only role-ids from role objects
-    mod_role_ids = set([r.id for r in get_mod_roles(member.guild.id)])
+    mod_role_ids = set([r.id for r in get_mod_roles(member.guild)])
     member_role_ids = set([r.id for r in member.roles])
     # intersecting sets to see if any role id is in both sets which means that user has mod perms
     intersect = mod_role_ids & member_role_ids

--- a/src/permission_management/moderator.py
+++ b/src/permission_management/moderator.py
@@ -1,0 +1,37 @@
+import logging
+from typing import List
+
+import discord
+
+import database.db_access as dba
+
+
+logger = logging.getLogger('my-bot')
+
+
+def get_mod_roles(guild: discord.Guild) -> List[discord.Member]:
+    """
+    Gets all roles that have moderator permissions inside the bot.\n
+    Removes roles that the bot can't find from database
+
+    :param guild: guild to search on
+
+    :return: List of all (moderator) roles (discord object) that the bot can find on the guild
+    """
+    # load roles
+    entries = dba.get_settings_for(guild.id, setting="mod-role")
+    if not entries:
+        return []
+    roles = []
+    for entry in entries:
+        role = guild.get_role(int(entry.value))
+        # if role can't be extracted it's probably deleted and should be removed
+        if not role:
+            logger.info(f"{guild.name}: Can't find role with ID {entry.id} - removing.")
+            dba.del_setting(guild.id, entry.value, entry.setting)
+            continue
+
+        roles.append(role)
+    return roles
+
+

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,3 +1,5 @@
+import re
+
 import discord
 from discord.errors import Forbidden
 
@@ -55,3 +57,16 @@ def make_embed(title="", color=blue_light, name="‌", value="‌", footer=None)
         emb.set_footer(text=footer)
 
     return emb
+
+
+def extract_id_from_message(content: str) -> int:
+    """
+    Scans string to extract user/guild/message id\n
+    Can extract IDs from mentions or plaintext
+    :return: extracted id
+    """
+    # matching string that has 18 digits surrounded by non-digits or start/end of string
+    match = re.match(r'(\D+|^)(\d{18})(\D+|$)', content)
+
+    return int(match.group(2)) if match else None
+


### PR DESCRIPTION
Hey, I propose the following changes:  

### Rename settings class to `Wordpools`   
### Add  `manage_moderator.py` cog:  
Cog contains one mayor function:  
 `toggle_mod()` this function called via `{PREFIX}}mod_role`  
This function allows an administrator to register roles that shall be able to edit the default word-pool for this server.  
The command is add  and remove command in one since it checks if an entry exists.  
If an entry exists: it will be deleted.  
Else: A new entry in the db will be created.

This whole functionality is buildt on the SETTINGS table and the functions from `db_access.py`.

Of course I also added a command to list all roles that can manage the pools

### Implement moderator check in  `Wordpools`
Now that we have this permissions in place, we can implement these in the Wordpools class, which I also did.   
`enlist` and `delist` both abort, if user doesn't have a role that has permissions.  
For I wrote an easy to use function called `is_moderator()` which handles the check for us.

### Other mentions:
* the worpools are now listed alphabetically 
* `utils` has now an `extract_id()` function
* some help messages were optimized