### PR TITLE
Add centralized missing permission embed, admin check and fix circular import

### DIFF
--- a/src/cogs/manage_moderators.py
+++ b/src/cogs/manage_moderators.py
@@ -9,6 +9,7 @@ import database.db as db
 import database.db_access as dba
 from environment import PREFIX
 from cogs.settings import is_arg
+from permission_management.admin import is_guild_admin
 from permission_management.moderator import get_mod_roles
 
 help_toggle_mod_usage = f"`{PREFIX}mrole [role id | @role]`"
@@ -22,7 +23,6 @@ class Access(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.has_permissions(administrator=True)
     @commands.command(name="mod-role", aliases=["mrole", "config-role", "selrole", "toggle_role", "crole"],
                       help="Allow roles to select the default wordpools.\n\n"
                            "This command _toggles_ the permissions for a role. \n"
@@ -31,6 +31,13 @@ class Access(commands.Cog):
 
                            f"_administrator permissions required_")
     async def toggle_mod(self, ctx: commands.Context, *role):
+
+        if not is_guild_admin(ctx.author):
+            await ut.send_embed(
+                ctx, ut.get_default_permission_message()
+            )
+            return
+
         if not is_arg(role, 1):
             await ctx.send(
                 embed=ut.make_embed(

--- a/src/cogs/settings.py
+++ b/src/cogs/settings.py
@@ -125,12 +125,10 @@ async def send_permission_error(ctx: commands.Context):
     - used in enlist and delist command
     """
     await ctx.send(
-        embed=ut.make_embed(
-            name="You cant do this",
-            value="I'm sorry, you don't have the permission to do that.\n"
-                  f"You can use `{PREFIX}mroles` get a list of all roles that have permissions.\n\n"
-                  f"Discord Admins can add roles using: `{PREFIX}mrole [role id | @role]`",
-            color=ut.yellow
+        embed=ut.get_default_permission_message(
+            missing_perm='`justOne-moderator`',
+            help_string=f"You can use `{PREFIX}mroles` get a list of all roles that have permissions.\n\n"
+                        f"Discord Admins can add roles using: `{PREFIX}mrole [role id | @role]`"
         )
     )
 

--- a/src/environment.py
+++ b/src/environment.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import utils as ut
 
 
 def load_env(key: str, default: str) -> str:
@@ -32,7 +31,6 @@ CHECK_EMOJI = '\u2705'
 DISMISS_EMOJI = '\u274C'
 DEFAULT_TIMEOUT = 300
 ROLE_NAME = 'JustOne-Guesser'
-ROLE_COLOR = ut.orange
 DEFAULT_DISTRIBUTION = [('classic_main', 1)]
 
 #  "classic_main", "classic_weird", "extension_main", "extension_weird", "nsfw", "gandhi"]

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -6,7 +6,7 @@ from discord.ext import commands
 from enum import Enum
 from typing import NewType, List, Union
 import utils as ut
-from environment import PREFIX, CHECK_EMOJI, DISMISS_EMOJI, DEFAULT_TIMEOUT, ROLE_NAME, ROLE_COLOR
+from environment import PREFIX, CHECK_EMOJI, DISMISS_EMOJI, DEFAULT_TIMEOUT, ROLE_NAME
 from game_management.tools import Hint, Phase, compute_proper_nickname, evaluate, hints2name_list
 from game_management.word_pools import getword, WordPoolDistribution
 import asyncio
@@ -296,7 +296,7 @@ class Game:
     async def remove_guesser_from_channel(self):
         # TODO: create a proper role for this channel and store it in self.role
         self.role = await self.channel.guild.create_role(name=ROLE_NAME + f": #{self.channel.name}")
-        await self.role.edit(color=ROLE_COLOR)
+        await self.role.edit(color=ut.orange)
         await self.channel.set_permissions(self.role, read_messages=False)
         await self.guesser.add_roles(self.role)
         dba.add_resource(self.channel.guild.id, self.role.id)

--- a/src/permission_management/admin.py
+++ b/src/permission_management/admin.py
@@ -1,0 +1,9 @@
+import discord
+
+
+def is_guild_admin(member: discord.Member) -> bool:
+    """
+    Shorthand for member.guild_permissions.administrator
+    :param member: discord.Memeber to check if admin
+    """
+    return member.guild_permissions.administrator

--- a/src/permission_management/moderator.py
+++ b/src/permission_management/moderator.py
@@ -4,6 +4,7 @@ from typing import List
 import discord
 
 import database.db_access as dba
+import permission_management.admin as admin
 
 
 logger = logging.getLogger('my-bot')
@@ -45,7 +46,7 @@ def is_moderator(member: discord.Member) -> bool:
     """
 
     # if member is an admin, he can do what ever he likes to do
-    if member.guild_permissions.administrator:
+    if admin.is_guild_admin(member):
         return True
 
     # load mod roles

--- a/src/utils.py
+++ b/src/utils.py
@@ -76,7 +76,7 @@ def extract_id_from_message(content: str) -> int:
 
 def get_default_permission_message(missing_perm='administrator',
                                    help_string=f'Use `{PREFIX}help` for more information',
-                                   color=orange) -> discord.Embed:
+                                   color=yellow) -> discord.Embed:
     """
     Generates central permission error message
 
@@ -88,7 +88,7 @@ def get_default_permission_message(missing_perm='administrator',
     """
     return make_embed(
         name="You can't do that.",
-        value=f"Hey, I'm sorry but you need {missing_perm} to do this.\n"
+        value=f"Hey, I'm sorry but you need {missing_perm} permissions to do this.\n"
               f"{help_string}",
         color=color
     )

--- a/src/utils.py
+++ b/src/utils.py
@@ -76,18 +76,21 @@ def extract_id_from_message(content: str) -> int:
 
 def get_default_permission_message(missing_perm='administrator',
                                    help_string=f'Use `{PREFIX}help` for more information',
-                                   color=yellow) -> discord.Embed:
+                                   color=yellow,
+                                   error_title="You can't do that."
+                                   ) -> discord.Embed:
     """
     Generates central permission error message
 
     :param missing_perm: The permission the member misses, e.g. 'bot moderator' or 'admin'
     :param help_string: String like 'Use !command_x to add permissions for that role'
     :param color: simply the discord.Color for this embed
+    :param error_title: To mix things up and use other titles if you want
 
     :return: Embed with permission message and additional help string
     """
     return make_embed(
-        name="You can't do that.",
+        name=error_title,
         value=f"Hey, I'm sorry but you need {missing_perm} permissions to do this.\n"
               f"{help_string}",
         color=color

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,10 @@
 import re
 
 import discord
+from discord.ext import commands
 from discord.errors import Forbidden
+
+from environment import PREFIX
 
 """
 The color presets, send_message() and make_embed() functions are included in the discord-bot template by nonchris
@@ -70,3 +73,22 @@ def extract_id_from_message(content: str) -> int:
 
     return int(match.group(2)) if match else None
 
+
+def get_default_permission_message(missing_perm='administrator',
+                                   help_string=f'Use `{PREFIX}help` for more information',
+                                   color=orange) -> discord.Embed:
+    """
+    Generates central permission error message
+
+    :param missing_perm: The permission the member misses, e.g. 'bot moderator' or 'admin'
+    :param help_string: String like 'Use !command_x to add permissions for that role'
+    :param color: simply the discord.Color for this embed
+
+    :return: Embed with permission message and additional help string
+    """
+    return make_embed(
+        name="You can't do that.",
+        value=f"Hey, I'm sorry but you need {missing_perm} to do this.\n"
+              f"{help_string}",
+        color=color
+    )


### PR DESCRIPTION
Hey, this PR contains three main changes:

Fix circular import:
* delete `ROLE_COLOR` from `environment.py` since it caused circular import errors importing `utils.py` into environment
* use `utils.color` instead

Add `is_guild_admin()` function in `permission_management/admin.py`
* file contains one short cut function at the moment
* use this command in code

Centralize error embed if user has not permissions to do something
* add centralized embed maker to return an 'error embed'
* replace `@commands.has_permissions(administrator)` with own admin check
* use central permission embed in `settings.py`