### PR TITLE
Correct logging and docstrings

### DIFF
--- a/src/cogs/manage_moderators.py
+++ b/src/cogs/manage_moderators.py
@@ -10,7 +10,7 @@ from permission_management.admin import is_guild_admin
 from permission_management.moderator import get_mod_roles
 from log_setup import logger
 
-help_toggle_mod_usage = f"`{PREFIX}mrole [role id | @role]`"
+help_toggle_mod_usage = f"`{PREFIX}mrole [@role | role_id]`"
 
 
 class Access(commands.Cog):
@@ -52,7 +52,7 @@ class Access(commands.Cog):
         if not role:
             await ctx.send(
                 embed=ut.make_embed(
-                    name="No ID given",
+                    name="No existing role ID given",
                     value=f"This command needs a role ID or a role mention as argument to work.\n\n"
                           f"Use: {help_toggle_mod_usage}\n\n",
                     color=ut.yellow

--- a/src/cogs/manage_moderators.py
+++ b/src/cogs/manage_moderators.py
@@ -8,6 +8,7 @@ from cogs.settings import is_arg
 from environment import PREFIX
 from permission_management.admin import is_guild_admin
 from permission_management.moderator import get_mod_roles
+from log_setup import logger
 
 help_toggle_mod_usage = f"`{PREFIX}mrole [role id | @role]`"
 
@@ -72,6 +73,7 @@ class Access(commands.Cog):
                     color=ut.orange
                 )
             )
+            logger.info(f'[Guild {ctx.guild.id}] Removed role {id_input} from the moderators list')
             return
 
         # we need to add a user if we reach this point - let's go
@@ -85,6 +87,7 @@ class Access(commands.Cog):
                 color=ut.green
             )
         )
+        logger.info(f'[Guild {ctx.guild.id}] Added role {id_input} to the moderators list')
 
     @commands.command(name='mroles', alias=['modroles', "modroles", "mod-roles"],
                       help='Display all roles that can configure the default wordpools')

--- a/src/cogs/settings.py
+++ b/src/cogs/settings.py
@@ -14,6 +14,7 @@ import database.db_access as dba
 from environment import PREFIX
 from game_management.word_pools import available_word_pools, get_description, get_words
 from permission_management.moderator import is_moderator
+from log_setup import logger
 
 
 def get_list_formatted(format_symbol="_", join_style="\n") -> str:
@@ -220,6 +221,7 @@ class Wordpools(commands.Cog):
                 value=f"List *{selected_list}* is already registered.\n"
                       f"Updated your weight to: {weight}"
             ))
+            logger.info(f'[Guild {ctx.guild.id}] Updated weight of {selected_list} to {weight}')
             return
 
         # no entry for the list exists - creating database entry
@@ -231,6 +233,7 @@ class Wordpools(commands.Cog):
                   f"Your active lists are now:\n\n{get_set_lists(ctx.guild.id)}"
         )
         )
+        logger.info(f'[Guild {ctx.guild.id} Enabled wordpool {selected_list} with weight {weight}')
 
     @commands.command(name="delist", alias=["dellist"], help="Deactivate a wordlist for your server\n\n"
                                                              f"Usage: `{PREFIX}delist [list_name]`")
@@ -255,6 +258,7 @@ class Wordpools(commands.Cog):
                   f"{active_lists}"
         )
         )
+        logger.info(f'[Guild {ctx.guild.id}] Deactivated wordpool {selected_list}')
 
 
 def setup(bot: commands.Bot):

--- a/src/cogs/settings.py
+++ b/src/cogs/settings.py
@@ -253,8 +253,8 @@ class Wordpools(commands.Cog):
         active_lists = get_set_lists(ctx.guild.id)
         await ctx.send(embed=ut.make_embed(
             name="Successfully removed",
-            value=f"The list *{selected_list}* was removed.\n\n"
-                  f"Your active lists are now:\n\n"
+            value=f"The wordpool *{selected_list}* was removed.\n\n"
+                  f"Your active wordpools are now:\n\n"
                   f"{active_lists}"
         )
         )

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -482,6 +482,7 @@ class Game:
                 logger.warn(f'{self.game_prefix}Admin channel was deleted manually. Please let me do this job!')
             # Delete admin channel from database
             dba.del_resource(self.channel.guild.id, value=self.admin_channel.id, resource_type="text_channel")
+            logger.info(f'{self.game_prefix()}Removed admin channel from database')
         await self.message_sender.message_handler.clear_messages(
             preserve_keys=[Key.summary, Key.abort],
             preserve_groups=[Group.other_bot, Group.user_chat]
@@ -530,6 +531,7 @@ class Game:
         await self.channel.set_permissions(self.role, read_messages=False)
         await self.guesser.add_roles(self.role)
         dba.add_resource(self.channel.guild.id, self.role.id)
+        logger.info(f'{self.game_prefix()}Added role to database.')
         self.role_given = True
 
     async def make_channel_for_admin(self):
@@ -552,6 +554,7 @@ class Game:
 
         # Add channel to created resources so we can delete it even after restart
         dba.add_resource(self.channel.guild.id, self.admin_channel.id, resource_type="text_channel")
+        logger.info(f'{self.game_prefix()}Added admin channel to database')
         # Give read access to the bot in the channel
         await self.admin_channel.set_permissions(self.channel.guild.me,
                                                  reason="Bot needs to have write access in the channel",
@@ -631,6 +634,7 @@ class Game:
         await self.guesser.remove_roles(self.role)
         await self.role.delete()
         dba.del_resource(self.channel.guild.id, value=self.role.id)
+        logger.info('f{self.game_prefix()}Removed role from database')
         self.role_given = False
         print('Added user back to channel')
 
@@ -691,6 +695,7 @@ class PhaseHandler:
         for phase in self.task_dictionary.keys():
             if (phase.value < 1000 or cancel_tasks) and self.task_dictionary[phase]:
                 self.task_dictionary[phase].cancel()
+        print('Clearing done')
 
     def advance_to_phase(self, phase: Phase):
         """

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -436,7 +436,7 @@ class Game:
         @param closed_mode: Whether to run the next game with a participant list (in closed_mode) or not
         @return: nothing, only used to end execution
         """
-        self.phase_handler.advance_to_phase(Phase.stopping)  # Stop the current game since we start a new one
+        # self.phase_handler.advance_to_phase(Phase.stopping)  # Stop the current game since we start a new one
         # Start a new game with the same people
         if len(self.participants) == 0:
             await self.message_sender.send_message(embed=output.warn_participant_list_empty(), reaction=False,

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -594,13 +594,14 @@ class Game:
                     reaction=False,
                     group=Group.warn
                 )
+                logger.info(f'{self.game_prefix()}Ignored possible hint by non-participant')
                 return
         else:
             if message.author not in self.participants:
                 self.participants.append(message.author)
-                print(f'Added {message.author} as a participant')
         # Now, add the hint properly
         self.hints.append(Hint(message))
+        logger.info(f'{self.game_prefix()}Received a hint')
         await self.message_sender.edit_message(
             key=Key.show_word,
             embed=output.announce_word_updated(self.guesser, self.word, self.hints,
@@ -622,6 +623,7 @@ class Game:
                     return
             else:
                 # Skip hint phase as we got every tip already
+                logger.info(f'{self.game_prefix()}Skipping collecting hints as all participants gave enough hints.')
                 self.phase_handler.advance_to_phase(Phase.show_all_hints_to_players)
 
     async def add_guesser_to_channel(self):

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -120,7 +120,7 @@ class Game:
         """
         logs the phase of the current game
         """
-        logger.info(f'{self.game_prefix}Started phase {self.phase}')
+        logger.info(f'{self.game_prefix()}Started phase {self.phase}')
 
     def play(self):
         """

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -636,7 +636,7 @@ class Game:
         await self.guesser.remove_roles(self.role)
         await self.role.delete()
         dba.del_resource(self.channel.guild.id, value=self.role.id)
-        logger.info('f{self.game_prefix()}Removed role from database')
+        logger.info(f'{self.game_prefix()}Removed role from database')
         self.role_given = False
         print('Added user back to channel')
 

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -15,7 +15,7 @@ from game_management.tools import Hint, Phase, evaluate, Key, Group
 from game_management.word_pools import getword, WordPoolDistribution
 from log_setup import logger
 
-games = []  # Global variable (what a shame!)
+games = []  # Global variable (what a shame!) -> Where can i better put this and e.g. use a dictionary for channels?
 
 
 class Game:

--- a/src/game_management/messages.py
+++ b/src/game_management/messages.py
@@ -202,8 +202,6 @@ class MessageSender:
             #  Only respond to reactions from non-bots with the correct emoji
             #  Optionally check if the user is the given member
             print('Checking reaction')
-            if user.id == reaction.message.channel.guild.me.id and str(reaction.emoji) == SKIP_EMOJI:
-                return True
             if member:
                 # print(f'User that reacted has id {user}, reacted with {str(reaction.emoji)} to message with id' f'{
                 # reaction.message.id}, while i wait for a reaction of {member.id} with {str(emoji)} to message with

--- a/src/game_management/messages.py
+++ b/src/game_management/messages.py
@@ -10,6 +10,9 @@ from game_management.tools import Key, Group
 
 
 class MessageHandler:  # Basic message handler for messages that one wants to send and later delete or fetch
+    """
+    Internal class for indexing messages a game has sent. Kind of like a small database
+    """
     def __init__(self, guild: discord.Guild, default_channel: discord.TextChannel):
         self.guild: discord.Guild = guild
         self.default_channel: discord.TextChannel = default_channel
@@ -107,8 +110,8 @@ class MessageSender:
                            channel: Union[discord.TextChannel, None] = None,
                            key: Key = Key.invalid, group: Group = Group.default) -> discord.Message:
         """
-        Sends a message in a channel and stores it in its message_handler and reacts to it with a given emoji if told
-        to do so
+        Sends a message in a channel and stores it in its message_handler and reacts to it with a given
+        (optional: list of) emoji if told to do so
         :param embed: The embedding of the message to send (can be empty)
         :param normal_text: The normal text of the message to send (can be empty)
         :param reaction: If a reaction is to be added
@@ -159,6 +162,11 @@ class MessageSender:
                 await message.edit(embed=embed)
 
     async def clear_reactions(self, key: Key):
+        """
+        Clears reactions from a message
+
+        @param key: Key of the message to clear reactions from
+        """
         message = await self.message_handler.get_special_message(key)
         try:
             await message.clear_reactions()

--- a/src/game_management/output.py
+++ b/src/game_management/output.py
@@ -6,6 +6,16 @@ import utils as ut
 from environment import PLAY_AGAIN_OPEN_EMOJI, PLAY_AGAIN_CLOSED_EMOJI
 from game_management.tools import Hint, hints2name_list, compute_proper_nickname
 
+"""
+This file contains all (german) text / messages that the bot will send during a game. They are called in various
+parts of the game and return embeddings or text. 
+Collection is centralised for better adjustion or even translation (future) of the messages.
+
+Some messages rely on attributes of the game. To not have circular imports, these attributes have to be passed to the
+methods in this file. However, these are always exactly the game attributes, so command invocation should be
+straightforward.
+"""
+
 
 def warning_head(reason: str) -> discord.Embed:
     return discord.Embed(title="Warnung!", color=ut.orange, description=reason)

--- a/src/game_management/word_pools.py
+++ b/src/game_management/word_pools.py
@@ -10,21 +10,45 @@ from environment import DEFAULT_DISTRIBUTION
 
 
 class WordPoolDistribution:  # Class used to manage the distribution of wordpools
+    """
+    Wrapper class representing a distribution of the word pools to be drawn of. Settings might be expanded in the future
+    so that guilds can save word pools with names for faster switching between them
+    """
     def __init__(self, distribution):  # Saves a natural number for each word_pool
+        """
+        Constructor for a WordPoolDistribution
+
+        @param distribution: List[(str,int)] representing pairs of (wordpool name, weight)
+                Currently, wordpool name can be one of the following:
+                classic_main, classic_weird, extension_main, extension_weird, nsfw, gandhi
+                For more, see available_word_pools() in this file
+        """
         self.distribution = distribution
 
     def get_distribution(self):  # Returns the distribution of itself. Method for future in case return type changes
         return self.distribution
 
     def __str__(self):
+        """
+        Nice representation of WordPoolDistribution for the logger
+        @return: String that contains info about the WordPoolDistribution
+        """
         return ', '.join([f"{pool} ({weight})" for (pool, weight) in self.distribution])
 
 
-def available_word_pools():  # Give back a list of the existing word pools (in the json file) - sorted
+def available_word_pools() -> List[str]:
+    """
+    @return: List[str]: A list of the existing word pools (in the json file) - sorted
+    """
     return sorted(get_wordpools().keys())
 
 
 def get_description(wordpool_name: str) -> Union[str, None]:
+    """
+    Get the description of a word pool
+    @param wordpool_name: str. The str name of the word pool to get a description from
+    @return: Union[str, None] Description of the wordpool if wordpool exists. None otherwise.
+    """
     #  Give back the description of a wordpool using its string name
     if wordpool_name in available_word_pools():
         return get_wordpools()[wordpool_name]['description']
@@ -39,12 +63,26 @@ def get_pools_with_description() -> List[Tuple[str, str]]:
 
 
 def get_words(wordpool_name: str) -> Union[List[str], None]:
+    """
+    Get the words in a word pool.
+    @param wordpool_name: str name of the word pool.
+    @return: List[str]. The list of words from this wordpool. None, if pool does not exist.
+    """
     # Give back the words contained in a wordpool using its string name
     if wordpool_name in available_word_pools():
         return get_wordpools()[wordpool_name]['words']
 
 
 def getword(word_pool_distribution: WordPoolDistribution):
+    """
+    Draw a word from the wordpools.
+    @param word_pool_distribution: The wordpool distribution to be drawn of
+    @return: A random word drawn from the wordpools according to the distribution as fallows:
+            We create a pool where each word is contained as often as the weight of its wordpool (so excluded if the
+            wordpool is not part of the WordPoolDistribution), and draw uniformly from it.
+            This is useful to weight smaller lists and thus draw from them more often, however also getting more
+            repeations within that list.
+    """
     # Choose a word using the given distribution of wordpools
     # Create the custom wordpool to draw a word from:
     pool: [str] = []
@@ -59,12 +97,21 @@ def getword(word_pool_distribution: WordPoolDistribution):
 
 
 def get_wordpools() -> dict:  # Reads the json file and returns a dictionary containing the wordpools. Internal function
+    """
+    Get the wordpools
+    @return: A dictionary containing the information of the wordpools
+    """
     with open('data/wordpools.json') as file:
         wordpool_dict = json.load(file)
     return wordpool_dict
 
 
 def compute_current_distribution(ctx: commands.Context) -> WordPoolDistribution:
+    """
+    Compute the current word pool distribution from the settings of the database server-specifically
+    @param ctx: The context (containing the server) from which to read the settings
+    @return: A WordPoolDistribution according to the current settings of the server
+    """
     # Computes the current WordPoolDistribution using the entries of the database (the enabled wordpools)
     distribution: List[(str, int)] = []
     if dba.get_settings_for(ctx.guild.id) is None:

--- a/src/game_management/word_pools.py
+++ b/src/game_management/word_pools.py
@@ -16,6 +16,9 @@ class WordPoolDistribution:  # Class used to manage the distribution of wordpool
     def get_distribution(self):  # Returns the distribution of itself. Method for future in case return type changes
         return self.distribution
 
+    def __str__(self):
+        return ', '.join([f"{pool} ({weight})" for (pool, weight) in self.distribution])
+
 
 def available_word_pools():  # Give back a list of the existing word pools (in the json file) - sorted
     return sorted(get_wordpools().keys())


### PR DESCRIPTION
# Logging
## The logger is now properly set up to log the following:
- For each game, a random game id is generated used to indicate all output related to that game
    - At game start, the number of participants, the used  wordpool distribution, th expected hints per participant and bools for admin_mode, repeation and quick delete mode are logged. Note this is all just metadata of the game, not private information.
    - While in a game, the logger logs the current phase of the game and when receiving a hint, using the above computed, randomized game id
    - Update with commit  12ea02e4a971144fa068b9c3af8646189044e454: When a word is drawn, we log the word pool drawn of
- We generally log when settings change on a guild by displaying the guild id and the following
    - When a wordpool is actived or deactived, this will show up in the log
    - When the moderators role list changes, this will be logged as well
## why? A log should give clear information about what a bot does when to help debug the bot if needed or retrace steps that the bot has done. All of the above are relevant things the bot does and one might want to retrace.
## What is *not* logged
We do not log any personal information, that is
- A game is not retracable on which guild it has been played, as it has a randomly generated id not related to the guild
- No participant ids or names are logged, only the number of them. You can play fully anonymously!
(Note that this of course applies only to the *log* that is generated, while in a game we have to *temporarily* track the participants, given hints etc. of course. However, all of this is deleted after the game again)

# Documentation
Introduced various docstrings to improve readability and maintainment of the code.