### PR TITLE
Aborting games possible in private chat

### DIFF
--- a/src/cogs/just_one.py
+++ b/src/cogs/just_one.py
@@ -63,7 +63,7 @@ class JustOne(commands.Cog):
                                          'If the round has a fixed participant list, command can only be issued by '
                                          'a participant')
     async def abort(self, ctx: commands.Context):
-        game = find_game(ctx.channel)
+        game = find_game(channel=ctx.channel, user=ctx.author)
         if game is None:
             print('abort command initiated in channel with no game')
             await ctx.send(embed=output.warning_no_round_running())

--- a/src/cogs/just_one.py
+++ b/src/cogs/just_one.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from discord.ext import commands, tasks
 
 import game_management.output as output
@@ -67,6 +69,7 @@ class JustOne(commands.Cog):
         if game is None:
             print('abort command initiated in channel with no game')
             await ctx.send(embed=output.warning_no_round_running())
+            return
         elif game.closed_game and ctx.author not in game.participants and ctx.author != game.guesser:
             print('abort command initiated by non-participant')
             return  # Ignore abort command by non-participating person. Warn message is sent otherwise
@@ -78,6 +81,9 @@ class JustOne(commands.Cog):
             print('abort command after game is finished')
             await game.message_sender.send_message(embed=output.warn_no_abort_anymore(), reaction=False,
                                                    group=Group.warn)
+        if ctx.guild is None:
+            await asyncio.sleep(1)  # Wait a second so that mentioning the channel will properly work
+            await ctx.send(embed=output.abortion_in_private_channel(channel=game.channel))
 
     @commands.command(name='correct', help='Tell the bot that your guess is correct. This can be used if the bot '
                                            'improperly rejects your guess.'

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -377,7 +377,7 @@ class Game:
         Takes a timer and stops the game after DEFAULT_TIMEOUT seconds if not cancelled before.
         This is to avoid users being locked away from channels if games are not being aborted.
         """
-        logger.info(f'{self.game_prefix}Game is open for {DEFAULT_TIMEOUT} seconds, closing then')
+        logger.info(f'{self.game_prefix()}Game is open for {DEFAULT_TIMEOUT} seconds, closing then')
         await asyncio.sleep(DEFAULT_TIMEOUT)
         self.phase_handler.advance_to_phase(Phase.stopping)
 

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -460,13 +460,13 @@ class Game:
         Aborts the current game. This includes adding the guesser back to the channel
         prints an appropriate message why the game has been aborted using attribute self.abort_reason
         """
+        if self.role_given:
+            await self.add_guesser_to_channel()
         await self.message_sender.send_message(
             embed=output.abort(self.abort_reason, self.word, self.guesser),
             reaction=False,
             key=Key.abort
         )
-        if self.role_given:
-            await self.add_guesser_to_channel()
         self.phase_handler.advance_to_phase(Phase.stopping)  # Stop the game now
 
     @tasks.loop(count=1)

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -200,7 +200,8 @@ class Game:
             logger.warn(f'{self.game_prefix}Did not get confirmation that Phase {self.phase} is done, aborting.')
             self.abort_reason = output.collect_hints_phase_not_ended()
             self.phase_handler.advance_to_phase(Phase.aborting)
-        self.phase_handler.advance_to_phase(Phase.show_all_hints_to_players)
+        else:
+            self.phase_handler.advance_to_phase(Phase.show_all_hints_to_players)
 
     @tasks.loop(count=1)
     async def show_all_hints_to_players(self):

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -137,7 +137,7 @@ class Game:
         """
         self.logger_inform_phase()
         await self.message_sender.send_message(output.round_started(
-            repeation=self.repeation, guesser=self.guesser, closed_game=self.closed_game
+            repeation=self.repeation, guesser=self.guesser, closed_game=self.closed_game, prefix=PREFIX
         ), reaction=False)
         await self.remove_guesser_from_channel()
 
@@ -509,6 +509,7 @@ class Game:
         @param member: The member of whom one wants to look for a message
         @return: The message the user has sent.
         """
+
         def check(message):
             return message.author == self.guesser and message.channel == self.channel
 
@@ -645,19 +646,21 @@ class Game:
 # End of Class Game
 
 
-def find_game(channel: discord.TextChannel) -> Union[Game, None]:
+def find_game(channel: discord.TextChannel = None, user: discord.User = None) -> Union[Game, None]:
     """
     Finds a game in the global variable of all games running in the channel
+    @param user: The member of whom to search for a game
     @param channel: The channel to be searched in
-    @return: The game running in the channel (if any). None otherwise.
+    @return: The game running in the channel or the game curently played by the member (if any). None otherwise.
     """
     # Gives back the game running in the current channel, None else
     global games
     if games is None:
         return None
     for game in games:
-        if game.channel.id == channel.id:
+        if (channel and game.channel.id == channel.id) or (user and game.guesser.id == user.id):
             return game
+    return None
 
 
 class PhaseHandler:

--- a/src/game_management/output.py
+++ b/src/game_management/output.py
@@ -277,3 +277,10 @@ def warn_no_abort_anymore():
 
 def warning_no_round_running():
     return warning_head('In diesem Kanal läuft aktuell gar keine Runde, ich ignoriere daher deinen Command.')
+
+
+def abortion_in_private_channel(channel: discord.TextChannel):
+    return ut.make_embed(name="Runde abgebrochen.",
+                         value=f"Die Runde, in der du ratender Spieler warst, wurde abgebrochen. Du kannst "
+                               f"{channel.mention} nun wieder betreten",
+                         color=ut.green)

--- a/src/game_management/output.py
+++ b/src/game_management/output.py
@@ -232,7 +232,7 @@ def already_running():
                         "Warte auf das Ende der aktuellen Runde, dann kann ich ein neues beginnen")
 
 
-def round_started(closed_game=False, repeation=False, guesser=None):
+def round_started(closed_game=False, repeation=False, guesser=None, prefix=""):
     if repeation:
         return ut.make_embed(name="Auf ein neues!",
                              value=f"Ich hab eine neue Runde mit den gleichen Teilnehmern und Einstellungen für euch "
@@ -242,8 +242,11 @@ def round_started(closed_game=False, repeation=False, guesser=None):
     return ut.make_embed(name="Okay", value=f"Die Runde{'mit einer festen Teilnehmerliste' if closed_game else ''} "
                                             f"ist gestartet. {guesser.mention} ist der ratende Spieler. Wundere dich "
                                             f"nicht, "
-                                            f"wenn du den Kanal nicht mehr siehst, dann verläuft alles nach Plan.\n"
-                                            f"Viel Spaß", color=ut.green)
+                                            f"wenn du den Kanal nicht mehr siehst, dann verläuft alles nach Plan, du"
+                                            f"kannst ihn dann automatisch wieder sehen, wenn du die Tipps erhältst.\n"
+                                            f"Viel Spaß", color=ut.green,
+                         footer=f"Wenn du früher wieder Zutritt zum Kanal haben willst, schreibe mir eine "
+                                f"Direktnachricht mit {prefix}abort, um die Runde abzubrechen.")
 
 
 def collect_hints_phase_not_ended():

--- a/src/game_management/output.py
+++ b/src/game_management/output.py
@@ -116,7 +116,7 @@ def summary(won: bool, word: str, guess: str, guesser: discord.Member, prefix: s
                         inline=False
                         )
 
-    if not won:
+    if not won and show_explanation:
         embed.set_footer(text=f"Nutzt {prefix}correct, falls die Antwort dennoch richtig ist")
 
     if corrected:

--- a/src/game_management/phases.py
+++ b/src/game_management/phases.py
@@ -37,15 +37,15 @@ class PhaseHandler:
 
     def advance_to_phase(self, phase: Phase):
         if phase.value >= 1000:
-            logger.error(f'{self.game.game_prefix}Tried to advance to Phase {phase}, but phase number is too high. '
+            logger.error(f'{self.game.game_prefix()}Tried to advance to Phase {phase}, but phase number is too high. '
                          f'Aborting phase advance')
             return
         if self.game.phase > phase:
-            logger.error(f'{self.game.game_prefix}Tried to advance to Phase {phase}, but game is already '
+            logger.error(f'{self.game.game_prefix()}Tried to advance to Phase {phase}, but game is already '
                          f'in phase {self.game.phase}, cannot go back in time. Aborting phase start.')
             return
         elif self.game.phase == phase:
-            logger.warn(f'{self.game.game_prefix}Tried to advance to Phase {phase}, but game is already '
+            logger.warn(f'{self.game.game_prefix()}Tried to advance to Phase {phase}, but game is already '
                         f'in that phase.'
                         f'Cannot start phase a second time.')
             return

--- a/src/game_management/tools.py
+++ b/src/game_management/tools.py
@@ -98,4 +98,7 @@ def evaluate(word: str, guess: str) -> bool:
 
 
 def compute_proper_nickname(member: discord.Member):
-    return member.nick if member.nick else member.name
+    if type(member) == discord.Member:
+        return member.nick if member.nick else member.name
+    else:
+        return member.name


### PR DESCRIPTION
We modify the !abort command so that it works in private channels:
- At beginning of the game, the explanation message has been changed to inform the guesser that he will be locked from the channel but can reenter using !abort
- Sending !abort to the bot in direct chat will now abort the round you are currently playing and gile you a message with a link to the channel the round was in
- You can then simply reenter the channel and the game is aborted