### PR TITLE
Better logging and error handling, using overwrites for locking user from channel

### DIFF
--- a/src/cogs/help.py
+++ b/src/cogs/help.py
@@ -3,6 +3,7 @@ from discord.ext import commands
 
 import utils as utl
 from environment import OWNER_NAME, OWNER_ID, VERSION, PREFIX
+from environment import DEBUG_MODE
 
 """
 This custom help command is a replacement for the default one on any Discord Bot written in discord.py!
@@ -72,7 +73,7 @@ class Help(commands.Cog):
             emb.add_field(name="About", value=f"The base of this Bot is developed by nonchris, using on discord.py.\n\
                                     This particular bot is maintained by {owner}\n\
                                     Please visit https://github.com/kesslermaximilian/JustOneBot to submit ideas or bugs.")
-            emb.set_footer(text=f"Bot is running Version: {VERSION}")
+            emb.set_footer(text=f"Bot is running Version: {VERSION}{' in debug mode' if DEBUG_MODE else ''}")
 
         # block called when one cog-name is given
         # trying to find matching cog and it's commands

--- a/src/cogs/just_one.py
+++ b/src/cogs/just_one.py
@@ -8,7 +8,7 @@ from environment import PREFIX, CHECK_EMOJI, DISMISS_EMOJI
 from game_management.game import Game, find_game, games
 from game_management.tools import Phase, Group, Key
 from game_management.word_pools import compute_current_distribution, getword
-from log_setup import logger
+from log_setup import logger, channel_prefix
 
 
 class JustOne(commands.Cog):
@@ -31,14 +31,16 @@ class JustOne(commands.Cog):
                            f'*Default players* None, anyone can participate.\n'
                            f'*Default hints per players* 3,2 and 1 for 1,2 and at least 3 participants respectively')
     async def play(self, ctx: commands.Context, *args):
+        logger.debug(f'{channel_prefix(ctx.channel)}Play command found.')
         compute_current_distribution(ctx=ctx)
         guesser = ctx.author
         text_channel = ctx.channel
         for game in games:
             if game.channel.id == text_channel.id:
+                logger.debug(f'{channel_prefix(ctx.channel)}Found a game in the channel in phase {game.phase}...')
                 if not (game.phase.value >= 130):  # Check if the game has a summary already
-
-                    print('There is already a game running in this channel, aborting...')
+                    logger.debug(f'{channel_prefix(ctx.channel)}...game is still playing, aborting play command and '
+                                 f'sending warning message')
                     await game.message_sender.send_message(
                         embed=output.already_running(),
                         reaction=False,
@@ -46,8 +48,11 @@ class JustOne(commands.Cog):
                     )
                     break  # We found a game that is already running, so break the loop
                 elif game.phase == Phase.show_summary:  # If the game is finished but not stopped, stop it
+                    logger.debug(f'{channel_prefix(ctx.channel)}...game can be stopped, stopping')
                     game.phase_handler.advance_to_phase(Phase.stopping)
         else:  # Now - if the loop did not break - we are ready to start a new game
+            logger.debug(f'{channel_prefix(ctx.channel)}Initialising new game, as no game is running or old game has '
+                         f'been stopped')
             game = Game(text_channel, guesser, bot=self.bot,
                         word_pool_distribution=compute_current_distribution(ctx=ctx),
                         participants=ut.get_members_from_args(ctx.guild, args),
@@ -56,6 +61,7 @@ class JustOne(commands.Cog):
 
             games.append(game)
             game.play()
+            logger.debug(f'{channel_prefix(ctx.channel)}Started new game')
 
     @commands.command(name='rules', help='Show the rules of this game.')
     async def rules(self, ctx):
@@ -67,21 +73,27 @@ class JustOne(commands.Cog):
                                          'a participant\n'
                                          'Can also be sent privately to the bot to abort the round where one is '
                                          'currently guessing')
-    async def abort(self, ctx: commands.Context):
+    async def abort(self, ctx: commands.Context):  # TODO: debug this
+        logger.debug(f'{channel_prefix(ctx.channel)}Abort command issued, checking for existing game')
         game = find_game(channel=ctx.channel, user=ctx.author)
         if game is None:
+            logger.debug(f'{channel_prefix(ctx.channel)}No game found in the current channel, sending warn message.')
             print('abort command initiated in channel with no game')
             await ctx.send(embed=output.warning_no_round_running())
             return
-        elif game.closed_game and ctx.author not in game.participants and ctx.author != game.guesser:
-            print('abort command initiated by non-participant')
+        else:
+            logger.debug(f'{channel_prefix(ctx.channel)}Found an existing game in phase {game.phase}')
+        if game.closed_game and ctx.author not in game.participants and ctx.author != game.guesser:
+            logger.debug(f'{channel_prefix(ctx.channel)}Game is in closed mode and command author not on participant'
+                         f' list or guesser. Ignoring the abort command.')
             return  # Ignore abort command by non-participating person. Warn message is sent otherwise
-        elif game.phase.value < 120:
-            print('processing abort command')
+        elif game.phase.value < 130:  # 130 is the value of the summary phase
+            logger.debug(f'{channel_prefix(ctx.channel)}Game has not finished yet, aborting it')
             game.abort_reason = output.manual_abort(ctx.author)
             game.phase_handler.advance_to_phase(Phase.aborting)
         else:
-            print('abort command after game is finished')
+            logger.debug(f'{channel_prefix(ctx.channel)}Game is already showing summary, being aborted, stopped or has'
+                         f' stopped already, no abort needed anymore. Sending warn message that this is the case.')
             await game.message_sender.send_message(embed=output.warn_no_abort_anymore(), reaction=False,
                                                    group=Group.warn)
         if ctx.guild is None:
@@ -122,32 +134,50 @@ class JustOne(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
+        logger.debug(f'{on_message_prefix(message)}Got a message, trying to find game in channel '
+                     f'{message.channel.id}...')
         channel = message.channel
         game = find_game(channel)
         if game is None:
+            logger.debug(f'{on_message_prefix(message)}No game found in channel, nothing to do')
             return  # since no game is running in this channel, nothing has to be done
 
+        logger.debug(f'{on_message_prefix(message)}Found game with id {game.id} in phase {game.phase} in the current'
+                     f'channel. Further handling of the message is needed')
         if message.author.bot:
             if message.author.id == message.channel.guild.me.id:
-                print('Found own bot message. Ignoring')  # TODO: what if other command from same bot is executed?
+                logger.debug(f'{on_message_prefix(message)}Message was written by myself, ignoring it.')
             else:
-                print('Found other bot message.')
-                # Add to category bot
-                # game.message_sender.message_handler.add_message_to_group(message, Group.other_bot_messages)
+                game.message_sender.message_handler.add_message_to_group(message, Group.other_bot)
+                logger.debug(f'{on_message_prefix(message)}Message was written by other bot, added it to group '
+                             f'{Group.other_bot} of the running game {game.id}')
+
         elif message.content.startswith(PREFIX):
-            print('Found a own bot command, ignoring it')
             game.message_sender.message_handler.add_message_to_group(message, Group.own_command_invocation)
-        #  We now know that the message is neither from a bot, nor a command invocation for our bot
-        # The game currently collects hints, so delete the message and add hint
-        elif game.phase == Phase.wait_collect_hints:
-            await message.delete()
+            logger.debug(f'{on_message_prefix(message)}Message is a command for myself, added it to group '
+                         f'{Group.own_command_invocation} of game {game.id}')
+        #  We now know that 1) there is game running in the current channel and 2) the message was sent by a real user
+        #  and 3) the message is not a command for our bot.
+        elif game.phase == Phase.wait_collect_hints:  # Check if game collects hints
+            # Check if we have to delete the message
+            if not game.closed_game or message.author in game.participants:
+                await message.delete()
+                logger.debug(f'{on_message_prefix(message)}Message was deleted as it will be processed as a hint by '
+                             f'the game')
             await game.add_hint(message)
-        elif game.phase == Phase.wait_for_guess:  # The game is waiting for a guess
+        elif game.phase == Phase.wait_for_guess:  # Check if game is waiting for a guess
             #  Check if message is from the guesser, if not, it is regular chat
-            if message.author != game.guesser:
-                game.message_sender.message_handler.add_message_to_group(message, group=Group.user_chat)  # Regular chat
-        else:  # regular chat
+            if message.author == game.guesser:
+                logger.debug(f'{on_message_prefix(message)}Message will be the guess of the game, nothing to do')
+                return
+        else:  # Message has to be regular chat
             game.message_sender.message_handler.add_message_to_group(message, group=Group.user_chat)
+            logger.debug(f'{on_message_prefix(message)}Message was added to group {Group.user_chat} of the game, '
+                         f'as it is not a hint or the guess for the game.')
+
+
+def on_message_prefix(message):
+    return f'[Message listener] [Message {message.id}] '
 
 
 # Setup the bot if this extension is loaded

--- a/src/environment.py
+++ b/src/environment.py
@@ -35,5 +35,6 @@ PLAY_AGAIN_OPEN_EMOJI = '\u21a9'
 DEFAULT_TIMEOUT = 600
 ROLE_NAME = 'JustOne-Guesser'
 DEFAULT_DISTRIBUTION = [('classic_main', 1)]
+DEBUG_MODE = True
 
 #  "classic_main", "classic_weird", "extension_main", "extension_weird", "nsfw", "gandhi"]

--- a/src/environment.py
+++ b/src/environment.py
@@ -22,9 +22,12 @@ logger = logging.getLogger('my-bot')
 
 TOKEN = os.getenv("TOKEN")  # reading in the token from config.py file
 
+git_version = str(subprocess.check_output((["git", "describe"])).strip())
+git_version = git_version[2:-2]
+
 # loading optional env variables
 PREFIX = load_env("PREFIX", "j!")
-VERSION = load_env("VERSION", str(subprocess.check_output(["git", "describe"]).strip()))  # version of the bot
+VERSION = load_env("VERSION", git_version)  # version of the bot
 OWNER_NAME = load_env("OWNER_NAME", "unknown")   # owner name with tag e.g. pi#3141
 OWNER_ID = int(load_env("OWNER_ID", "100000000000000000"))  # discord id of the owner
 CHECK_EMOJI = '\u2705'

--- a/src/environment.py
+++ b/src/environment.py
@@ -1,6 +1,6 @@
 import os
 import logging
-
+import subprocess
 
 def load_env(key: str, default: str) -> str:
     """
@@ -24,7 +24,7 @@ TOKEN = os.getenv("TOKEN")  # reading in the token from config.py file
 
 # loading optional env variables
 PREFIX = load_env("PREFIX", "j!")
-VERSION = load_env("VERSION", "unknown")  # version of the bot
+VERSION = load_env("VERSION", str(subprocess.check_output(["git", "describe"]).strip()))  # version of the bot
 OWNER_NAME = load_env("OWNER_NAME", "unknown")   # owner name with tag e.g. pi#3141
 OWNER_ID = int(load_env("OWNER_ID", "100000000000000000"))  # discord id of the owner
 CHECK_EMOJI = '\u2705'

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -496,7 +496,8 @@ class Game:
             except discord.NotFound:
                 logger.warn(f'{self.game_prefix}Admin channel was deleted manually. Please let me do this job!')
             # Delete admin channel from database
-            dba.del_resource(self.channel.guild.id, value=self.admin_channel.id, resource_type="text_channel")
+            if self.admin_channel:
+                dba.del_resource(self.channel.guild.id, value=self.admin_channel.id, resource_type="text_channel")
             logger.info(f'{self.game_prefix()}Removed admin channel from database')
         await self.message_sender.message_handler.clear_messages(
             preserve_keys=[Key.summary, Key.abort],
@@ -563,7 +564,8 @@ class Game:
         except discord.Forbidden:
             logger.fatal(f'{self.game_prefix()}Could not assign role to guesser.')
             await self.fatal_forbidden()
-        dba.add_resource(self.channel.guild.id, self.role.id)
+        if self.admin_channel:
+            dba.add_resource(self.channel.guild.id, self.role.id)
         logger.info(f'{self.game_prefix()}Added role to database.')
         self.role_given = True
 

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -713,7 +713,7 @@ class Game:
                   "able to work properly, at least for this channel.\n"
                   "Also note that the current guesser could be locked out accidentally, a non-deleted role with name "
                   f"{ROLE_NAME}: {self.channel.name} could be around as well as a channel called "
-                  f"{self.admin_channel.name} that have now to be manually readjusted.",
+                  f"{self.channel.name}-warteraum that have now to be manually readjusted.",
             footer=f"Please inform the server admins of this issue with game id {self.id}",
             color=ut.red
         ))

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -709,7 +709,6 @@ class Game:
         logger.info(f'{self.game_prefix()}Added user back to channel')
 
     async def fatal_forbidden(self):
-        self.phase_handler.advance_to_phase(Phase.stopping)
         if self.role_given:
             await self.add_guesser_to_channel()
         await self.channel.send(embed=ut.make_embed(
@@ -724,6 +723,7 @@ class Game:
             footer=f"Please inform the server admins of this issue with game id {self.id}",
             color=ut.red
         ))
+        self.phase_handler.advance_to_phase(Phase.stopping)
 
 # End of Class Game
 

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -302,7 +302,8 @@ class Game:
         await self.message_sender.message_handler.delete_group(Group.filter_hint)
         await self.message_sender.message_handler.delete_special_message(Key.show_word)
         # Inform admin to enter the channel
-        await self.message_sender.send_message(channel=self.admin_channel,
+        if self.admin_channel:
+            await self.message_sender.send_message(channel=self.admin_channel,
                                                embed=output.inform_admin_to_reenter_channel(channel=self.channel),
                                                reaction=False,
                                                key=Key.admin_inform_reenter
@@ -603,7 +604,8 @@ class Game:
         logger.info(f'{self.game_prefix()}Added admin channel to database')
         # Give read access to the bot in the channel
         try:
-            await self.admin_channel.set_permissions(self.channel.guild.me,
+            if self.admin_channel:
+                await self.admin_channel.set_permissions(self.channel.guild.me,
                                                      reason="Bot needs to have write access in the channel",
                                                      read_messages=True)
         except discord.Forbidden:
@@ -611,7 +613,8 @@ class Game:
             self.phase_handler.start_task(Phase.fatal_forbidden)
         # Hide channel to other users
         try:
-            await self.admin_channel.set_permissions(self.channel.guild.default_role,
+            if self.admin_channel:
+                await self.admin_channel.set_permissions(self.channel.guild.default_role,
                                                      reason="Make admin channel only visible to admin himself",
                                                      read_messages=False)
         except discord.Forbidden:
@@ -619,17 +622,18 @@ class Game:
             self.phase_handler.start_task(Phase.fatal_forbidden)
 
         # Show message so that Admin can quickly jump to the channel
-        await self.message_sender.send_message(reaction=False,
+        if self.admin_channel:
+            await self.message_sender.send_message(reaction=False,
                                                embed=output.admin_mode_wait(self.guesser, self.admin_channel),
                                                key=Key.admin_wait)
-
-        await self.message_sender.send_message(
-            embed=output.admin_welcome(self.guesser, emoji=CHECK_EMOJI),
-            channel=self.admin_channel,
-            normal_text=self.guesser.mention,
-            reaction=True,
-            key=Key.admin_welcome
-        )
+        if self.admin_channel:
+            await self.message_sender.send_message(
+                embed=output.admin_welcome(self.guesser, emoji=CHECK_EMOJI),
+                channel=self.admin_channel,
+                normal_text=self.guesser.mention,
+                reaction=True,
+                key=Key.admin_welcome
+            )
 
     # External methods called by listeners
     async def add_hint(self, message):

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -50,6 +50,8 @@ class Game:
                 according on the number of players playing in the game as three, two and one hints for one, two and
                 at least three players, respectively
         """
+        self.id = random.getrandbits(64)
+        logger.debug(f'{self.game_prefix()}Constructor invoked')
         self.channel = channel
         self.guesser = guesser
         self.guesser_overwrites = None  # channel specific overwrites of the guesser in the game channel
@@ -79,8 +81,11 @@ class Game:
         if self.guesser in self.participants:
             self.participants.remove(self.guesser)  # Remove guesser from participants
 
+        logger.debug(f'{self.game_prefix()}Game has participants {self.participants} and is '
+                     f'{"" if self.closed_game else"not " }in closed mode')
+
         # Parse the expected_tips_person:
-        print(f'expected before: {expected_tips_per_person}')
+        logger.debug(f'{self.game_prefix()}Argument of expected hints is {expected_tips_per_person}')
         if self.closed_game:
             if expected_tips_per_person != 0:
                 self.expected_tips_per_person = expected_tips_per_person  # Argument was given
@@ -95,10 +100,8 @@ class Game:
         else:
             self.expected_tips_per_person = 0  # In this round the parameter is not used anyways, but setting it to 0
             # ensure smart setting of the parameter when another round is played
+        logger.debug(f'{self.game_prefix()}Expected hints per person now set to {self.expected_tips_per_person}')
 
-        print(f"Participants of this round: {self.participants}, game is in closed mode = {self.closed_game}")
-
-        self.id = random.getrandbits(64)
         self.aborted = False
         self.role_given = False
         self.role: discord.Role = None
@@ -107,13 +110,15 @@ class Game:
         self.won = None
         self.bot = bot
         self.clearing = True
-        print(f'Game started in channel {self.channel} by user {self.guesser}')
         logger.info(f'{self.game_prefix()}Initialised game with {len(self.participants)} participants. '
-                    f'Wordpool distribution: {self.wordpool}, admin mode: {self.admin_mode}, '
+                    f'admin mode: {self.admin_mode}, '
+                    f'closed game: {self.closed_game}, '
                     f'expected hints per participant: {self.expected_tips_per_person}, '
                     f'repeation: {self.repeation}, '
-                    f'quick delete mode: {self.quick_delete}'
+                    f'quick delete mode: {self.quick_delete}, '
+                    f'Wordpool distribution: {self.wordpool}'
                     )
+        logger.debug(f'{self.game_prefix()}Guesser of the game is {self.guesser}, running in channel {self.channel.id}')
 
     def game_prefix(self):
         """
@@ -346,9 +351,9 @@ class Game:
 
         # Check if we got a guess
         if guess is None:
-            print('No guess found, aborting')  # TODO better log here, also better function!
+            logger.info(f'{self.game_prefix()}No guess found, aborting')  # TODO better log here, also better function!
             return
-        print(f'Guess is {guess}')
+        logger.debug(f'{self.game_prefix()}Guess is {guess}')
         self.message_sender.message_handler.add_special_message(message=guess, key=Key.guess)
         # future: don't delete guess immediately but make it edible ?
         self.guess = guess.content
@@ -443,7 +448,6 @@ class Game:
         @param closed_mode: Whether to run the next game with a participant list (in closed_mode) or not
         @return: nothing, only used to end execution
         """
-        # self.phase_handler.advance_to_phase(Phase.stopping)  # Stop the current game since we start a new one
         # Start a new game with the same people
         if len(self.participants) == 0:
             await self.message_sender.send_message(embed=output.warn_participant_list_empty(), reaction=False,
@@ -484,7 +488,10 @@ class Game:
         if self.admin_mode:
             try:
                 if self.admin_channel:  # Admin channel could have been not created yet
-                    await self.admin_channel.delete()
+                    try:
+                        await self.admin_channel.delete()
+                    except discord.Forbidden:
+                        logger.fatal(f'{self.game_prefix()}Could not delete the admin channel.')
             except discord.NotFound:
                 logger.warn(f'{self.game_prefix}Admin channel was deleted manually. Please let me do this job!')
             # Delete admin channel from database
@@ -533,12 +540,24 @@ class Game:
         Removes the guesser from the current channel by assigning him a role. Manages the permissions of the role and
         the channel
         """
-        # TODO: create a proper role for this channel and store it in self.role
-        self.role = await self.channel.guild.create_role(name=ROLE_NAME + f": #{self.channel.name}")
-        await self.role.edit(color=ut.orange)
-        self.guesser_overwrites = self.channel.overwrites_for(self.guesser)
-        await self.channel.set_permissions(self.guesser, read_messages=False)
-        await self.guesser.add_roles(self.role)
+        try:
+            self.role = await self.channel.guild.create_role(name=ROLE_NAME + f": #{self.channel.name}")
+            await self.role.edit(color=ut.orange)
+        except discord.Forbidden:
+            logger.fatal(f'{self.game_prefix()}Could not create role for this game')
+        try:
+            self.guesser_overwrites = self.channel.overwrites_for(self.guesser)
+        except discord.Forbidden:
+            logger.fatal(f'{self.game_prefix()}Could not read guesser overwrites of the guesser from the current '
+                         f'channel')
+        try:
+            await self.channel.set_permissions(self.guesser, read_messages=False)
+        except discord.Forbidden:
+            logger.fatal(f'{self.game_prefix()}Could not set reading permissions of the guesser in the game channel')
+        try:
+            await self.guesser.add_roles(self.role)
+        except discord.Forbidden:
+            logger.fatal(f'{self.game_prefix()}Could not assign role to guesser.')
         dba.add_resource(self.channel.guild.id, self.role.id)
         logger.info(f'{self.game_prefix()}Added role to database.')
         self.role_given = True
@@ -551,29 +570,41 @@ class Game:
         self.admin_mode = True  # Mark this game as having admin mode
         # Create channel for the admin in proper category
         if self.channel.category:
-            self.admin_channel = await self.channel.category.create_text_channel(
-                name=output.admin_channel_name(self.channel),
-                reason="Create waiting channel",
-                overwrites={self.role: discord.PermissionOverwrite(view_channel=True, add_reactions=True)}
-            )
+            try:
+                self.admin_channel = await self.channel.category.create_text_channel(
+                    name=output.admin_channel_name(self.channel),
+                    reason="Create waiting channel",
+                    overwrites={self.role: discord.PermissionOverwrite(view_channel=True, add_reactions=True)}
+                )
+            except discord.Forbidden:
+                logger.fatal(f'{self.game_prefix()}Could not create admin channel in category properly')
         else:
-            self.admin_channel = await self.channel.guild.create_text_channel(
-                name=output.admin_channel_name(self.channel.name),
-                reason="Create waiting channel",
-                overwrites={self.role: discord.PermissionOverwrite(view_channel=True, add_reactions=True)}
-            )
+            try:
+                self.admin_channel = await self.channel.guild.create_text_channel(
+                    name=output.admin_channel_name(self.channel.name),
+                    reason="Create waiting channel",
+                    overwrites={self.role: discord.PermissionOverwrite(view_channel=True, add_reactions=True)}
+                )
+            except discord.Forbidden:
+                logger.fatal(f'{self.game_prefix()}Could not create admin channel in default category properly')
 
         # Add channel to created resources so we can delete it even after restart
         dba.add_resource(self.channel.guild.id, self.admin_channel.id, resource_type="text_channel")
         logger.info(f'{self.game_prefix()}Added admin channel to database')
         # Give read access to the bot in the channel
-        await self.admin_channel.set_permissions(self.channel.guild.me,
-                                                 reason="Bot needs to have write access in the channel",
-                                                 read_messages=True)
+        try:
+            await self.admin_channel.set_permissions(self.channel.guild.me,
+                                                     reason="Bot needs to have write access in the channel",
+                                                     read_messages=True)
+        except discord.Forbidden:
+            logger.fatal(f'{self.game_prefix()}Could not grant bot read access to admin channel')
         # Hide channel to other users
-        await self.admin_channel.set_permissions(self.channel.guild.default_role,
-                                                 reason="Make admin channel only visible to admin himself",
-                                                 read_messages=False)
+        try:
+            await self.admin_channel.set_permissions(self.channel.guild.default_role,
+                                                     reason="Make admin channel only visible to admin himself",
+                                                     read_messages=False)
+        except discord.Forbidden:
+            logger.fatal(f'{self.game_prefix()}Could not forbid access to admin channel for @everyone')
 
         # Show message so that Admin can quickly jump to the channel
         await self.message_sender.send_message(reaction=False,
@@ -643,16 +674,38 @@ class Game:
         """
         guild = await self.bot.fetch_guild(self.channel.guild.id)
         self.role = guild.get_role(self.role.id)
-        print('Role deleted, user should be back in channel')
-        await self.guesser.remove_roles(self.role)
-        await self.role.delete()
+        try:
+            await self.guesser.remove_roles(self.role)
+        except discord.Forbidden:
+            logger.fatal(f'{self.game_prefix()}Could not remove role from guesser.')
+        try:
+            await self.role.delete()
+        except discord.Forbidden:
+            logger.fatal(f'{self.game_prefix()}Could not delete role')
+        logger.info('Role deleted, user should be back in channel')
         # re-add user back to channel with overwrites he had before
-        await self.channel.set_permissions(self.guesser, overwrite=self.guesser_overwrites)
+        try:
+            await self.channel.set_permissions(self.guesser, overwrite=self.guesser_overwrites)
+        except discord.Forbidden:
+            logger.fatal(f'{self.game_prefix()}Could not set guesser overwrites for the current channel')
         dba.del_resource(self.channel.guild.id, value=self.role.id)
         logger.info(f'{self.game_prefix()}Removed role from database')
         self.role_given = False
-        print('Added user back to channel')
+        logger.info(f'{self.game_prefix()}Added user back to channel')
 
+    async def fatal_forbidden(self):
+        await self.channel.send(embed=ut.make_embed(
+            title="A fatal error occurred",
+            name="I did not have the necessary permissions to do one of my actions.",
+            value="In case you don't change something with my permissions, this is a permanent error and I won't be "
+                  "able to work properly, at least for this channel.\n"
+                  "Also note that the current guesser could be locked out accidentally, a non-deleted role with name "
+                  f"{ROLE_NAME}: {self.channel.name} could be around as well as a channel called "
+                  f"{self.admin_channel.name} that have now to be manually readjusted.",
+            footer=f"Please inform the server admins of this issue with game id {self.id}",
+            color=ut.red
+        ))
+        self.phase_handler.advance_to_phase(Phase.aborting)
 
 # End of Class Game
 
@@ -717,11 +770,11 @@ class PhaseHandler:
         Cancels all running phases of the game ond optionally tasks as well
         @param cancel_tasks: Whether to cancel the tasks as well
         """
-        print(f'Cancelling all phases{" and tasks" if cancel_tasks else ""}')
+        logger.debug(f'{self.game.game_prefix()}Cancelling all phases{" and tasks" if cancel_tasks else ""}')
         for phase in self.task_dictionary.keys():
             if (phase.value < 1000 or cancel_tasks) and self.task_dictionary[phase]:
                 self.task_dictionary[phase].cancel()
-        print('Clearing done')
+        logger.debug(f'{self.game.game_prefix()}Clearing of phases and tasks done.')
 
     def advance_to_phase(self, phase: Phase):
         """
@@ -731,6 +784,8 @@ class PhaseHandler:
         @param phase: The phase to advance the game to
         @return: nothing, only used for stopping execution
         """
+        logger.debug(f'{self.game.game_prefix()}Trying to advance to phase {phase}, currently in phase '
+                     f'{self.game.phase}')
         if phase.value >= 1000:
             logger.error(f'{self.game.game_prefix()}Tried to advance to Phase {phase}, but phase number is too high. '
                          f'Aborting phase advance')
@@ -749,6 +804,8 @@ class PhaseHandler:
             self.cancel_all(phase == Phase.stopping)
             if self.task_dictionary[phase]:
                 self.task_dictionary[phase].start()
+            logger.debug(f'{self.game.game_prefix()}Successfully advanced to phase {self.game.phase} and started '
+                         f'corresponding task')
 
     def start_task(self, phase: Phase, **kwargs):
         """

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -714,7 +714,7 @@ class Game:
                   "*Also note that the current guesser could be locked out accidentally*,"
                   "\n a non-deleted role with name "
                   f"`{ROLE_NAME}: {self.channel.name}` or a channel called "
-                  f"`{self.channel.name}-warteraum` that have now to be manually readjusted.",
+                  f"`{self.channel.name}-warteraum` could still exist that have now to be manually readjusted.",
             footer=f"Please inform the server admins of this issue with game id {self.id}",
             color=ut.red
         ))

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -82,7 +82,7 @@ class Game:
             self.participants.remove(self.guesser)  # Remove guesser from participants
 
         logger.debug(f'{self.game_prefix()}Game has participants {self.participants} and is '
-                     f'{"" if self.closed_game else"not " }in closed mode')
+                     f'{"" if self.closed_game else "not "}in closed mode')
 
         # Parse the expected_tips_person:
         logger.debug(f'{self.game_prefix()}Argument of expected hints is {expected_tips_per_person}')
@@ -303,10 +303,10 @@ class Game:
         # Inform admin to enter the channel
         if self.admin_channel:
             await self.message_sender.send_message(channel=self.admin_channel,
-                                               embed=output.inform_admin_to_reenter_channel(channel=self.channel),
-                                               reaction=False,
-                                               key=Key.admin_inform_reenter
-                                               )
+                                                   embed=output.inform_admin_to_reenter_channel(channel=self.channel),
+                                                   reaction=False,
+                                                   key=Key.admin_inform_reenter
+                                                   )
         self.phase_handler.advance_to_phase(Phase.remove_role_from_guesser)
 
     @tasks.loop(count=1)
@@ -512,8 +512,8 @@ class Game:
                 self.won, self.word, self.guess, self.guesser, PREFIX, self.hints,
                 evaluate(self.word, self.guess) != self.won,
                 show_explanation=False
-                )
             )
+                                                   )
         self.phase = Phase.stopped
         global games
         try:
@@ -608,8 +608,8 @@ class Game:
         try:
             if self.admin_channel:
                 await self.admin_channel.set_permissions(self.channel.guild.me,
-                                                     reason="Bot needs to have write access in the channel",
-                                                     read_messages=True)
+                                                         reason="Bot needs to have write access in the channel",
+                                                         read_messages=True)
         except discord.Forbidden:
             logger.fatal(f'{self.game_prefix()}Could not grant bot read access to admin channel')
             self.phase_handler.start_task(Phase.fatal_forbidden)
@@ -617,8 +617,8 @@ class Game:
         try:
             if self.admin_channel:
                 await self.admin_channel.set_permissions(self.channel.guild.default_role,
-                                                     reason="Make admin channel only visible to admin himself",
-                                                     read_messages=False)
+                                                         reason="Make admin channel only visible to admin himself",
+                                                         read_messages=False)
         except discord.Forbidden:
             logger.fatal(f'{self.game_prefix()}Could not forbid access to admin channel for @everyone')
             self.phase_handler.start_task(Phase.fatal_forbidden)
@@ -626,8 +626,8 @@ class Game:
         # Show message so that Admin can quickly jump to the channel
         if self.admin_channel:
             await self.message_sender.send_message(reaction=False,
-                                               embed=output.admin_mode_wait(self.guesser, self.admin_channel),
-                                               key=Key.admin_wait)
+                                                   embed=output.admin_mode_wait(self.guesser, self.admin_channel),
+                                                   key=Key.admin_wait)
         if self.admin_channel:
             await self.message_sender.send_message(
                 embed=output.admin_welcome(self.guesser, emoji=CHECK_EMOJI),
@@ -742,7 +742,7 @@ def find_game(channel: discord.TextChannel = None, user: discord.User = None) ->
     Finds a game in the global variable of all games running in the channel
     @param user: The member of whom to search for a game
     @param channel: The channel to be searched in
-    @return: The game running in the channel or the game curently played by the member (if any). None otherwise.
+    @return: The game running in the channel or the game currently played by the member (if any). None otherwise.
     """
     # Gives back the game running in the current channel, None else
     global games
@@ -764,6 +764,7 @@ class PhaseHandler:
         possible actions from a user, we start one task for each possible reaction, and the task who finishes first
         informs the PhaseHandler and the PhaseHandler can then cancel the other job)
         """
+
     def __init__(self, game: Game):
         self.game = game
         self.task_dictionary = {

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -492,6 +492,7 @@ class Game:
                         await self.admin_channel.delete()
                     except discord.Forbidden:
                         logger.fatal(f'{self.game_prefix()}Could not delete the admin channel.')
+                        await self.fatal_forbidden()
             except discord.NotFound:
                 logger.warn(f'{self.game_prefix}Admin channel was deleted manually. Please let me do this job!')
             # Delete admin channel from database
@@ -545,19 +546,23 @@ class Game:
             await self.role.edit(color=ut.orange)
         except discord.Forbidden:
             logger.fatal(f'{self.game_prefix()}Could not create role for this game')
+            await self.fatal_forbidden()
         try:
             self.guesser_overwrites = self.channel.overwrites_for(self.guesser)
         except discord.Forbidden:
             logger.fatal(f'{self.game_prefix()}Could not read guesser overwrites of the guesser from the current '
                          f'channel')
+            await self.fatal_forbidden()
         try:
             await self.channel.set_permissions(self.guesser, read_messages=False)
         except discord.Forbidden:
             logger.fatal(f'{self.game_prefix()}Could not set reading permissions of the guesser in the game channel')
+            await self.fatal_forbidden()
         try:
             await self.guesser.add_roles(self.role)
         except discord.Forbidden:
             logger.fatal(f'{self.game_prefix()}Could not assign role to guesser.')
+            await self.fatal_forbidden()
         dba.add_resource(self.channel.guild.id, self.role.id)
         logger.info(f'{self.game_prefix()}Added role to database.')
         self.role_given = True
@@ -578,6 +583,7 @@ class Game:
                 )
             except discord.Forbidden:
                 logger.fatal(f'{self.game_prefix()}Could not create admin channel in category properly')
+                await self.fatal_forbidden()
         else:
             try:
                 self.admin_channel = await self.channel.guild.create_text_channel(
@@ -587,6 +593,7 @@ class Game:
                 )
             except discord.Forbidden:
                 logger.fatal(f'{self.game_prefix()}Could not create admin channel in default category properly')
+                await self.fatal_forbidden()
 
         # Add channel to created resources so we can delete it even after restart
         dba.add_resource(self.channel.guild.id, self.admin_channel.id, resource_type="text_channel")
@@ -598,6 +605,7 @@ class Game:
                                                      read_messages=True)
         except discord.Forbidden:
             logger.fatal(f'{self.game_prefix()}Could not grant bot read access to admin channel')
+            await self.fatal_forbidden()
         # Hide channel to other users
         try:
             await self.admin_channel.set_permissions(self.channel.guild.default_role,
@@ -605,6 +613,7 @@ class Game:
                                                      read_messages=False)
         except discord.Forbidden:
             logger.fatal(f'{self.game_prefix()}Could not forbid access to admin channel for @everyone')
+            await self.fatal_forbidden()
 
         # Show message so that Admin can quickly jump to the channel
         await self.message_sender.send_message(reaction=False,
@@ -678,16 +687,19 @@ class Game:
             await self.guesser.remove_roles(self.role)
         except discord.Forbidden:
             logger.fatal(f'{self.game_prefix()}Could not remove role from guesser.')
+            await self.fatal_forbidden()
         try:
             await self.role.delete()
         except discord.Forbidden:
             logger.fatal(f'{self.game_prefix()}Could not delete role')
+            await self.fatal_forbidden()
         logger.info('Role deleted, user should be back in channel')
         # re-add user back to channel with overwrites he had before
         try:
             await self.channel.set_permissions(self.guesser, overwrite=self.guesser_overwrites)
         except discord.Forbidden:
             logger.fatal(f'{self.game_prefix()}Could not set guesser overwrites for the current channel')
+            await self.fatal_forbidden()
         dba.del_resource(self.channel.guild.id, value=self.role.id)
         logger.info(f'{self.game_prefix()}Removed role from database')
         self.role_given = False

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -105,7 +105,6 @@ class Game:
         self.aborted = False
         self.role_given = False
         self.role: discord.Role = None
-        self.summary_message: discord.Message = None
         self.phase = Phase.initialised
         self.won = None
         self.bot = bot
@@ -504,14 +503,17 @@ class Game:
             preserve_keys=[Key.summary, Key.abort],
             preserve_groups=[Group.other_bot, Group.user_chat]
         )  # Clearing (almost) everything the bot has sent
-        # TODO: check if summary message was sent
-        await self.message_sender.clear_reactions(key=Key.summary)
-        await self.message_sender.edit_message(key=Key.summary, embed=output.summary(
-            self.won, self.word, self.guess, self.guesser, PREFIX, self.hints,
-            evaluate(self.word, self.guess) != self.won,
-            show_explanation=False
-        )
-                                               )
+        # We now want to remove reactions from the summary message and edit it to not show the explanations anymore
+        # But we don't know if the message was sent, as the game could have stopped earlier. We can check this by
+        # checking if a guess is already stored somewhere:
+        if self.guess:
+            await self.message_sender.clear_reactions(key=Key.summary)
+            await self.message_sender.edit_message(key=Key.summary, embed=output.summary(
+                self.won, self.word, self.guess, self.guesser, PREFIX, self.hints,
+                evaluate(self.word, self.guess) != self.won,
+                show_explanation=False
+                )
+            )
         self.phase = Phase.stopped
         global games
         try:

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -598,7 +598,8 @@ class Game:
                 await self.fatal_forbidden()
 
         # Add channel to created resources so we can delete it even after restart
-        dba.add_resource(self.channel.guild.id, self.admin_channel.id, resource_type="text_channel")
+        if self.admin_channel:
+            dba.add_resource(self.channel.guild.id, self.admin_channel.id, resource_type="text_channel")
         logger.info(f'{self.game_prefix()}Added admin channel to database')
         # Give read access to the bot in the channel
         try:
@@ -708,6 +709,9 @@ class Game:
         logger.info(f'{self.game_prefix()}Added user back to channel')
 
     async def fatal_forbidden(self):
+        self.phase_handler.advance_to_phase(Phase.stopping)
+        if self.role_given:
+            await self.add_guesser_to_channel()
         await self.channel.send(embed=ut.make_embed(
             title="A fatal error occurred",
             name="I did not have the necessary permissions to do one of my actions.",
@@ -720,7 +724,6 @@ class Game:
             footer=f"Please inform the server admins of this issue with game id {self.id}",
             color=ut.red
         ))
-        self.phase_handler.advance_to_phase(Phase.aborting)
 
 # End of Class Game
 

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -551,12 +551,14 @@ class Game:
         if self.channel.category:
             self.admin_channel = await self.channel.category.create_text_channel(
                 name=output.admin_channel_name(self.channel),
-                reason="Create waiting channel"
+                reason="Create waiting channel",
+                overwrites={self.role: discord.PermissionOverwrite(view_channel=True, add_reactions=True)}
             )
         else:
             self.admin_channel = await self.channel.guild.create_text_channel(
                 name=output.admin_channel_name(self.channel.name),
-                reason="Create waiting channel"
+                reason="Create waiting channel",
+                overwrites={self.role: discord.PermissionOverwrite(view_channel=True, add_reactions=True)}
             )
 
         # Add channel to created resources so we can delete it even after restart

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -711,9 +711,10 @@ class Game:
             name="I did not have the necessary permissions to do one of my actions.",
             value="In case you don't change something with my permissions, this is a permanent error and I won't be "
                   "able to work properly, at least for this channel.\n"
-                  "Also note that the current guesser could be locked out accidentally, a non-deleted role with name "
-                  f"{ROLE_NAME}: {self.channel.name} could be around as well as a channel called "
-                  f"{self.channel.name}-warteraum that have now to be manually readjusted.",
+                  "*Also note that the current guesser could be locked out accidentally*,"
+                  "\n a non-deleted role with name "
+                  f"`{ROLE_NAME}: {self.channel.name}` or a channel called "
+                  f"`{self.channel.name}-warteraum` that have now to be manually readjusted.",
             footer=f"Please inform the server admins of this issue with game id {self.id}",
             color=ut.red
         ))

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -711,6 +711,7 @@ class Game:
     async def fatal_forbidden(self):
         if self.role_given:
             await self.add_guesser_to_channel()
+        self.phase_handler.advance_to_phase(Phase.stopping)
         await self.channel.send(embed=ut.make_embed(
             title="A fatal error occurred",
             name="I did not have the necessary permissions to do one of my actions.",
@@ -723,7 +724,7 @@ class Game:
             footer=f"Please inform the server admins of this issue with game id {self.id}",
             color=ut.red
         ))
-        self.phase_handler.advance_to_phase(Phase.stopping)
+
 
 # End of Class Game
 

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -711,7 +711,7 @@ class Game:
     async def fatal_forbidden(self):
         if self.role_given:
             await self.add_guesser_to_channel()
-        self.phase_handler.advance_to_phase(Phase.stopping)
+        self.phase_handler.cancel_all(cancel_tasks=True)
         await self.channel.send(embed=ut.make_embed(
             title="A fatal error occurred",
             name="I did not have the necessary permissions to do one of my actions.",
@@ -724,6 +724,7 @@ class Game:
             footer=f"Please inform the server admins of this issue with game id {self.id}",
             color=ut.red
         ))
+        self.phase_handler.advance_to_phase(Phase.stopping)
 
 
 # End of Class Game

--- a/src/game_management/game.py
+++ b/src/game_management/game.py
@@ -535,7 +535,7 @@ class Game:
         # TODO: create a proper role for this channel and store it in self.role
         self.role = await self.channel.guild.create_role(name=ROLE_NAME + f": #{self.channel.name}")
         await self.role.edit(color=ut.orange)
-        await self.channel.set_permissions(self.role, read_messages=False)
+        await self.channel.set_permissions(self.guesser, read_messages=False)
         await self.guesser.add_roles(self.role)
         dba.add_resource(self.channel.guild.id, self.role.id)
         logger.info(f'{self.game_prefix()}Added role to database.')
@@ -644,6 +644,7 @@ class Game:
         print('Role deleted, user should be back in channel')
         await self.guesser.remove_roles(self.role)
         await self.role.delete()
+        await self.channel.set_permissions(self.guesser, overwrite=None)
         dba.del_resource(self.channel.guild.id, value=self.role.id)
         logger.info(f'{self.game_prefix()}Removed role from database')
         self.role_given = False

--- a/src/game_management/messages.py
+++ b/src/game_management/messages.py
@@ -92,51 +92,78 @@ class MessageHandler:  # Basic message handler for messages that one wants to se
                      f' with id {message_id}')
         channel: discord.TextChannel = self.guild.get_channel(channel_id=channel_id)
         if channel is None:
-            print('Channel not found while trying to fetch a message from channel. Ignoring')
+            logger.warn(f'{message_handler_prefix()}Channel with id {channel_id} does not exist anymore.')
             return None
         try:
-            print(f'Returning message in channel {channel.name} with id {message_id}')
-            message = await channel.fetch_message(message_id)
+            message = await channel.fetch_message(message_id)  # Getting message. Throws error, if not existing
+            logger.debug(f'Returning message in channel {channel.name} with id {message_id}')
             return message
         except discord.NotFound:
-            print('Tried to fetch message from channel that does not exist anymore')
+            logger.warn(f'{message_handler_prefix()}Message with id {message_id} not found in channel {channel_id}')
             return None
 
     async def get_special_message(self, key: Key) -> Union[discord.Message, None]:
-        print(f'Getting special message with key {key}')
+        """
+        Fetch a message that was previously indexed by a key
+
+        @param key: Key the message has been indexed before
+        @return: The message (if exists), None otherwise
+        """
+        logger.debug(f'{message_handler_prefix()}Trying to get special message with key {key}')
         try:
             entry = self.special_messages[key]
         except KeyError:
+            logger.error(f'{message_handler_prefix()}Special message with key {key} has never been indexed.')
             return None
         if entry is None:
-            print(f'No entry for {key} in the database')
+            logger.error(f'{message_handler_prefix()}No entry for key {key} in the database, nothing to fetch.')
             return None
         (channel_id, message_id) = entry
-        message = await self._fetch_message_from_channel(channel_id, message_id)
-        return message
+        message = await self._fetch_message_from_channel(channel_id, message_id)  # Proper error handling is done here
+        return message  # Could be None if message did not exist
 
     async def delete_special_message(self, key: Key, pop=True):
+        """
+        Delete a message using the key it has been indexed before.
+
+        @param key: key under which the message has been indexed
+        @param pop: Whether to pop the the entry of the message from the dictionary that stores it
+        @return: nothing
+        """
+        logger.debug(f'{message_handler_prefix()}Trying to delete special message wih key {key}')
         message: discord.Message = await self.get_special_message(key)
         if message is None:
-            print(f'Failed to delete message with special key {key}')
+            logger.warn(f'{message_handler_prefix()}Message with key {key} not found, nothing to delete here.')
             return
         else:
             await message.delete()
+            logger.debug(f'{message_handler_prefix()}Deleting message with id {message.id}')
         if pop:
             self.special_messages.pop(key)
+            logger.debug(f'{message_handler_prefix()}Successfully popped key {key} from special message dictionary')
 
     async def clear_messages(self, preserve_keys: List[Key] = [], preserve_groups: List[Group] = []):
-        print(self.group_messages)
-        for group_key in self.group_messages.keys():
-            if group_key not in preserve_groups:
-                await self.delete_group(group_key)
+        """
+        Clears the messages that have been indexed before
 
-        print(f"Special messages (dict): {self.special_messages}\n")
+        @param preserve_keys: List of keys of the message one does NOT want to delete
+        @param preserve_groups: List of groups of messages one does NOT want to delete
+        @return:
+        """
+        logger.debug(f'{preserve_keys}Clearing messages except keys {preserve_keys} and groups {preserve_groups}')
+
         special_message_keys = [special_message_key for special_message_key in self.special_messages.keys()]
         for special_message_key in special_message_keys:
-            print(f"Checking key {special_message_key} within list {preserve_keys}")
+            logger.debug(f"{message_handler_prefix()}Checking key {special_message_key} within preserving list"
+                         f" {preserve_keys}")
             if special_message_key not in preserve_keys:
                 await self.delete_special_message(special_message_key, pop=True)
+
+        for group_key in self.group_messages.keys():
+            logger.debug(f'{message_handler_prefix()}Checking group {group_key} within preserving list'
+                         f' {preserve_groups}')
+            if group_key not in preserve_groups:
+                await self.delete_group(group_key)
 
 
 class MessageSender:
@@ -144,6 +171,9 @@ class MessageSender:
         self.guild = guild
         self.default_channel = default_channel
         self.message_handler = MessageHandler(guild=guild, default_channel=default_channel)
+
+    def message_sender_prefix(self):
+        return f'[Message Sender] '
 
     async def send_message(self, embed: Union[None, discord.Embed], normal_text="", reaction=True,
                            emoji: Union[Union[discord.Emoji, discord.Reaction, discord.PartialEmoji, str],
@@ -243,7 +273,7 @@ class MessageSender:
         def check(reaction, user):
             #  Only respond to reactions from non-bots with the correct emoji
             #  Optionally check if the user is the given member
-            print('Checking reaction')
+            logger.debug(f'{self.message_sender_prefix()}Found a reaction, checking if valid...')
             if member:
                 # print(f'User that reacted has id {user}, reacted with {str(reaction.emoji)} to message with id' f'{
                 # reaction.message.id}, while i wait for a reaction of {member.id} with {str(emoji)} to message with
@@ -256,24 +286,30 @@ class MessageSender:
             else:
                 return (not user.bot or react_to_bot) and str(reaction.emoji) == emoji and reaction.message == message
 
-        print(f'waiting for reaction with key {message_key}{f" by {member.name}" if member else ""}')
+        logger.debug(f'{self.message_sender_prefix()}'
+                     f'Waiting for reaction to message with key {message_key}{f" by {member.name}" if member else ""}')
         try:
             reaction, user = await bot.wait_for('reaction_add', timeout=warning_time, check=check)
-            print('found reaction')
+            logger.debug(f'{self.message_sender_prefix()}...reaction valid, returning True')
             return True  # Notify that reaction was found
         except asyncio.TimeoutError:
+            logger.debug(f'{self.message_sender_prefix()}Got no reaction to message {message.id}.')
             if timeout == 0:
                 return False
-            print('No reaction, send warning')
-            # TODO check if warning is appropriate, i.e. if the original message still exists. Else, abort this
+            logger.debug(f'{self.message_sender_prefix()}Sending a warning to user')
             try:
                 await self.send_message(normal_text=f"Hey, {member.mention if member else ''}",
                                         embed=warning, reaction=False, channel=message.channel, group=Group.warn)
             except discord.NotFound:  # In case the channel does not exist anymore
+                logger.error(f'{self.message_sender_prefix()}The channel of the message I am waiting for a reaction '
+                             f'does not exist anymore.')
                 return False
             # Try a second time
+            logger.debug(f'{self.message_sender_prefix()}Trying to wait a second time')
             try:
                 reaction, user = await bot.wait_for('reaction_add', timeout=timeout, check=check)
+                logger.debug(f'{self.message_sender_prefix()}Found reaction (on second try), returning True')
                 return True  # Notify that reaction was found
             except asyncio.TimeoutError:
+                logger.debug(f'{self.message_sender_prefix()}Failed to get a reaction, returning False')
                 return False  # Notify that timeout has happened

--- a/src/game_management/output.py
+++ b/src/game_management/output.py
@@ -263,8 +263,8 @@ def not_guessed():
 
 def warn_participant_list_empty() -> discord.Embed:
     return warning_head(
-        "Ihr seid aber Trolle! Ich kann kein neues Spiel mit den gleichen Teilnehmern starten, weil dieses keine "
-        "(ratenden) Teilnehmer hat, und ich die ratende Person nicht rotieren kann!")
+        "Ihr seid aber Trolle! Ich kann kein neues Spiel starten, weil dieses keine "
+        "(ratenden) Teilnehmer hat, und ich die ratende Person somit nicht rotieren kann!")
 
 
 def manual_abort(author):

--- a/src/game_management/tools.py
+++ b/src/game_management/tools.py
@@ -61,6 +61,7 @@ class Phase(Enum):
     wait_for_stop_game_after_timeout = 1002
     clear_messages = 1003
     play_new_game = 1004
+    fatal_forbidden = 1005
 
 
 class Key(Enum):

--- a/src/log_setup.py
+++ b/src/log_setup.py
@@ -18,6 +18,11 @@ console_logger = logging.StreamHandler()
 console_logger.setLevel(logging.WARNING)  # only important stuff to the terminal
 console_logger.setFormatter(formatter)
 
+# debug logger
+debug_logger = logging.StreamHandler()
+debug_logger.setLevel(logging.DEBUG)
+debug_logger.setFormatter(formatter)
+
 # get new logger
 logger = logging.getLogger('my-bot')
 logger.setLevel(logging.INFO)
@@ -25,3 +30,8 @@ logger.setLevel(logging.INFO)
 # register loggers
 logger.addHandler(file_logger)
 logger.addHandler(console_logger)
+logger.addHandler(debug_logger)
+
+
+def channel_prefix(channel):
+    return f'[Channel {channel.id}] '

--- a/src/log_setup.py
+++ b/src/log_setup.py
@@ -20,10 +20,15 @@ console_logger = logging.StreamHandler()
 console_logger.setLevel(logging.WARNING)  # only important stuff to the terminal
 console_logger.setFormatter(formatter)
 
-# debug logger
+# debug logger for console
 debug_logger = logging.StreamHandler()
 debug_logger.setLevel(logging.DEBUG)
 debug_logger.setFormatter(formatter)
+
+# debug logger for file
+file_debug_logger = logging.FileHandler('data/debug.log')
+file_debug_logger.setLevel(logging.DEBUG)
+file_debug_logger.setFormatter(formatter)
 
 # get new logger
 logger = logging.getLogger('my-bot')
@@ -36,6 +41,7 @@ else:
 logger.addHandler(file_logger)
 logger.addHandler(console_logger)
 logger.addHandler(debug_logger)
+logger.addHandler(file_debug_logger)
 
 
 def channel_prefix(channel):

--- a/src/log_setup.py
+++ b/src/log_setup.py
@@ -1,6 +1,8 @@
 import os
 import logging
 
+from environment import DEBUG_MODE
+
 # path for databases or config files
 if not os.path.exists('data/'):
     os.mkdir('data/')
@@ -25,7 +27,10 @@ debug_logger.setFormatter(formatter)
 
 # get new logger
 logger = logging.getLogger('my-bot')
-logger.setLevel(logging.INFO)
+if DEBUG_MODE:
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.INFO)
 
 # register loggers
 logger.addHandler(file_logger)


### PR DESCRIPTION
# Game changes
Previously, we tried to prohibit the guesser read access to the channel by assigning him a role and setting the roles's permissions. While this is fine for default-visible roles, this does not work if the user already has a role that explicitly enables him to see the current channel, as the newly created role by the bot will be under the user-role in the server role hierarchy. To fix this issue, we now adjust the bot to
- Use user-overwrites for the channel. This means that we now set the user-overwrites for reading messages in the guessing-channel to false explicitly so that the user cannot see the channel anymore (except if the user is an admin).
- We restore the _correct_ user-overwrites after the game, i.e. to None  / True as they were before. This means that after a game has finished, the server settings for roles and channel are *exactly* the same as before, as one would wish, of course

# Error handling with permission errors
- Sometimes the bot may lack permissions to perform an action that would be relevant for the game. This is for example the case if an admin channel is to created in a category the bot has no permissions in.
- The bot now throws an according 'fatal error' if this happens, aborting the current round and informing the members on the server that the bot won't work with these settings.
- The error message is really scary, but as long as the bot's permissions did not change _during_ a round the bot was playing, everything should be actually fine (except that the bot won't work in the current channel)
    - the bot will still try to restore all settings as they have been before the round started.
    - But, of course, if e.g. the bot locks out a guesser from a channel and you _then_ remove the bot's permissions to edit the channel access, the bot can't edit the permissions to let the guesser in again.  
    - Just don't mess with the bot's permissions during a round and you will be alright

# Inputting the git commit of the bot into the bot's version
- We use git tags and `git describe` to automatically read in the current git comit the bot is running on. This information is displayed in the `j!help` message in the footer. This way, it is possible to easily relate a running version of the bot to the exact source code the bot usese.
- This version can be overwritten by setting the environment variable via `export VERSION=` in the terminal (in the `src` directory of the bot)
- Note that if you did not clone (or similar) this repository with git, the importing of the version will fail. You can then just remove all git-related lines in `environment.py` and still run the bot correctly by manually setting whatever version you like.

# Better logging
- All console output has now been moved to use the logger.
- There is now a debug mode of the bot including many more logging (which usually is disturbing to just see what the bot is doing)
    - We use a central constant `DEBUG` defined in `environment.py` to enable this mode centrally
    - This enables a second logger-handler to write debug output to `debug.log`. This does not change the usual `events.log` file, so you get two seperated, clean files
    - Display if the bot is running in debug-mode in the `j!help` command so you if the bot is printing such a file currently

